### PR TITLE
[Vortex-54] Change terminology for edge types

### DIFF
--- a/src/main/java/edu/snu/vortex/compiler/frontend/beam/Visitor.java
+++ b/src/main/java/edu/snu/vortex/compiler/frontend/beam/Visitor.java
@@ -99,7 +99,7 @@ final class Visitor extends Pipeline.PipelineVisitor.Defaults {
       parDo.getSideInputs().stream()
           .filter(pValueToOpOutput::containsKey)
           .map(pValueToOpOutput::get)
-          .forEach(src -> builder.connectOperators(src, vortexOperator, Edge.Type.O2O)); // Broadcasted = O2O
+          .forEach(src -> builder.connectOperators(src, vortexOperator, Edge.Type.OneToOne)); // Broadcasted = OneToOne
       return vortexOperator;
     } else {
       throw new UnsupportedOperationException(transform.toString());
@@ -108,11 +108,11 @@ final class Visitor extends Pipeline.PipelineVisitor.Defaults {
 
   private Edge.Type getInEdgeType(final Operator operator) {
     if (operator instanceof edu.snu.vortex.compiler.ir.operator.GroupByKey) {
-      return Edge.Type.M2M;
+      return Edge.Type.ScatterGather;
     } else if (operator instanceof Broadcast) {
-      return Edge.Type.O2M;
+      return Edge.Type.Broadcast;
     } else {
-      return Edge.Type.O2O;
+      return Edge.Type.OneToOne;
     }
   }
 }

--- a/src/main/java/edu/snu/vortex/compiler/ir/Edge.java
+++ b/src/main/java/edu/snu/vortex/compiler/ir/Edge.java
@@ -29,9 +29,9 @@ public final class Edge<I, O> {
    * Type of edges.
    */
   public enum Type {
-    M2M,
-    O2M,
-    O2O,
+    ScatterGather,
+    Broadcast,
+    OneToOne,
   }
 
   private final String id;

--- a/src/main/java/edu/snu/vortex/compiler/optimizer/Optimizer.java
+++ b/src/main/java/edu/snu/vortex/compiler/optimizer/Optimizer.java
@@ -57,7 +57,7 @@ public final class Optimizer {
   }
 
   private boolean hasM2M(final List<Edge> edges) {
-    return edges.stream().filter(edge -> edge.getType() == Edge.Type.M2M).count() > 0;
+    return edges.stream().filter(edge -> edge.getType() == Edge.Type.ScatterGather).count() > 0;
   }
 
   private boolean allFromReserved(final List<Edge> edges) {
@@ -77,7 +77,7 @@ public final class Optimizer {
           } else if (fromReservedToTransient(edge)) {
             edge.setAttr(Attributes.Key.EdgeChannel, Attributes.EdgeChannel.File);
           } else {
-            if (edge.getType().equals(Edge.Type.O2O)) {
+            if (edge.getType().equals(Edge.Type.OneToOne)) {
               edge.setAttr(Attributes.Key.EdgeChannel, Attributes.EdgeChannel.Memory);
             } else {
               edge.setAttr(Attributes.Key.EdgeChannel, Attributes.EdgeChannel.File);

--- a/src/main/java/edu/snu/vortex/compiler/optimizer/examples/MapReduce.java
+++ b/src/main/java/edu/snu/vortex/compiler/optimizer/examples/MapReduce.java
@@ -43,8 +43,8 @@ public final class MapReduce {
     builder.addOperator(source);
     builder.addOperator(map);
     builder.addOperator(reduce);
-    builder.connectOperators(source, map, Edge.Type.O2O);
-    builder.connectOperators(map, reduce, Edge.Type.M2M);
+    builder.connectOperators(source, map, Edge.Type.OneToOne);
+    builder.connectOperators(map, reduce, Edge.Type.ScatterGather);
     final DAG dag = builder.build();
     System.out.println("Before Optimization");
     System.out.println(dag);

--- a/src/main/java/edu/snu/vortex/runtime/common/example/ExecutionPlanGeneration.java
+++ b/src/main/java/edu/snu/vortex/runtime/common/example/ExecutionPlanGeneration.java
@@ -134,11 +134,11 @@ public final class ExecutionPlanGeneration {
 
   private static RtAttributes.CommPattern convertEdgeTypeToROpLinkAttr(final Edge.Type edgeType) {
     switch (edgeType) {
-      case O2O:
+      case OneToOne:
         return RtAttributes.CommPattern.ONE_TO_ONE;
-      case O2M:
+      case Broadcast:
         return RtAttributes.CommPattern.BROADCAST;
-      case M2M:
+      case ScatterGather:
         return RtAttributes.CommPattern.SCATTER_GATHER;
       default:
         throw new RuntimeException("no such edge type");
@@ -162,7 +162,7 @@ public final class ExecutionPlanGeneration {
     return (!edges.isPresent());
   }
   private static boolean hasM2M(final List<Edge> edges) {
-    return edges.stream().filter(edge -> edge.getType() == Edge.Type.M2M).count() > 0;
+    return edges.stream().filter(edge -> edge.getType() == Edge.Type.ScatterGather).count() > 0;
   }
 
   private static DAG buildMapReduceIRDAG() {
@@ -175,8 +175,8 @@ public final class ExecutionPlanGeneration {
     builder.addOperator(source);
     builder.addOperator(map);
     builder.addOperator(reduce);
-    builder.connectOperators(source, map, Edge.Type.O2O);
-    builder.connectOperators(map, reduce, Edge.Type.M2M);
+    builder.connectOperators(source, map, Edge.Type.OneToOne);
+    builder.connectOperators(map, reduce, Edge.Type.ScatterGather);
     return builder.build();
   }
 


### PR DESCRIPTION
This PR:

- Changes the terminology for edge types as following:
  - O2O -> OneToOne
  - O2M -> Broadcast
  - M2M -> ScatterGather

Resolves #54 