### PR TITLE
[MINOR] Make Runtime Exceptions 'final'

### DIFF
--- a/src/main/java/edu/snu/vortex/runtime/exception/IllegalEdgeOperationException.java
+++ b/src/main/java/edu/snu/vortex/runtime/exception/IllegalEdgeOperationException.java
@@ -17,8 +17,10 @@ package edu.snu.vortex.runtime.exception;
 
 /**
  * IllegalEdgeOperationException.
+ * Thrown when an operation is conducted with a {@link edu.snu.vortex.runtime.common.plan.logical.RuntimeEdge}
+ * that is unknown/invalid/out of scope.
  */
-public class IllegalEdgeOperationException extends RuntimeException {
+public final class IllegalEdgeOperationException extends RuntimeException {
   /**
    * IllegalEdgeOperationException.
    * @param message message

--- a/src/main/java/edu/snu/vortex/runtime/exception/IllegalVertexOperationException.java
+++ b/src/main/java/edu/snu/vortex/runtime/exception/IllegalVertexOperationException.java
@@ -17,8 +17,10 @@ package edu.snu.vortex.runtime.exception;
 
 /**
  * IllegalVertexOperationException.
+ * Thrown when an operation is conducted with a {@link edu.snu.vortex.runtime.common.plan.logical.RuntimeVertex}
+ * that is unknown/invalid/out of scope.
  */
-public class IllegalVertexOperationException extends RuntimeException {
+public final class IllegalVertexOperationException extends RuntimeException {
   /**
    * IllegalVertexOperationException.
    * @param message message

--- a/src/main/java/edu/snu/vortex/runtime/exception/PhysicalPlanGenerationException.java
+++ b/src/main/java/edu/snu/vortex/runtime/exception/PhysicalPlanGenerationException.java
@@ -17,8 +17,11 @@ package edu.snu.vortex.runtime.exception;
 
 /**
  * PhysicalPlanGenerationException.
+ * Thrown when any exception occurs during the conversion
+ * from {@link edu.snu.vortex.runtime.common.plan.logical.ExecutionPlan}
+ * to {@link edu.snu.vortex.runtime.common.plan.physical.PhysicalPlan}
  */
-public class PhysicalPlanGenerationException extends RuntimeException {
+public final class PhysicalPlanGenerationException extends RuntimeException {
   /**
    * PhysicalPlanGenerationException.
    * @param message message

--- a/src/main/java/edu/snu/vortex/runtime/exception/UnsupportedAttributeException.java
+++ b/src/main/java/edu/snu/vortex/runtime/exception/UnsupportedAttributeException.java
@@ -17,8 +17,9 @@ package edu.snu.vortex.runtime.exception;
 
 /**
  * UnsupportedAttributeException.
+ * Thrown when Runtime does not support the attribute or the attribute is unknown.
  */
-public class UnsupportedAttributeException extends RuntimeException {
+public final class UnsupportedAttributeException extends RuntimeException {
   /**
    * UnsupportedAttributeException.
    * @param message message


### PR DESCRIPTION
Runtime exceptions lack comments and are not 'final'.
This minor PR improves these two small issues so that future exceptions follow a minimal convention.