### PR TITLE
[Vortex-86] Introduce States in Runtime

### DIFF
--- a/src/main/java/edu/snu/vortex/runtime/common/state/JobState.java
+++ b/src/main/java/edu/snu/vortex/runtime/common/state/JobState.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2017 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.vortex.runtime.common.state;
+
+import edu.snu.vortex.utils.StateMachine;
+
+/**
+ * Represents the states and their transitions of a {@link edu.snu.vortex.runtime.common.plan.physical.PhysicalPlan}.
+ */
+public final class JobState {
+  private final StateMachine stateMachine;
+
+  public JobState() {
+    stateMachine = buildTaskGroupStateMachine();
+  }
+
+  private StateMachine buildTaskGroupStateMachine() {
+    final StateMachine.Builder stateMachineBuilder = StateMachine.newBuilder();
+
+    // Add states
+    stateMachineBuilder.addState(State.READY, "The job has been created and submitted to runtime.");
+    stateMachineBuilder.addState(State.EXECUTING, "The job is executing (with its stages executing).");
+    stateMachineBuilder.addState(State.COMPLETE, "The job is complete.");
+    stateMachineBuilder.addState(State.FAILED, "Job failed.");
+
+    // Add transitions
+    stateMachineBuilder.addTransition(State.READY, State.EXECUTING,
+        "Begin executing!");
+    stateMachineBuilder.addTransition(State.EXECUTING, State.COMPLETE,
+        "All stages complete, job complete");
+
+    stateMachineBuilder.addTransition(State.READY, State.FAILED,
+        "Master failure");
+    stateMachineBuilder.addTransition(State.EXECUTING, State.FAILED,
+        "Executor failure");
+
+    stateMachineBuilder.setInitialState(State.READY);
+
+    return stateMachineBuilder.build();
+  }
+
+  /**
+   * Job states.
+   */
+  public enum State {
+    READY,
+    EXECUTING,
+    COMPLETE,
+    FAILED
+  }
+}

--- a/src/main/java/edu/snu/vortex/runtime/common/state/StageState.java
+++ b/src/main/java/edu/snu/vortex/runtime/common/state/StageState.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2017 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.vortex.runtime.common.state;
+
+import edu.snu.vortex.utils.StateMachine;
+
+/**
+ * Represents the states and their transitions of a {@link edu.snu.vortex.runtime.common.plan.physical.PhysicalStage}.
+ */
+public final class StageState {
+  private final StateMachine stateMachine;
+
+  public StageState() {
+    stateMachine = buildTaskGroupStateMachine();
+  }
+
+  private StateMachine buildTaskGroupStateMachine() {
+    final StateMachine.Builder stateMachineBuilder = StateMachine.newBuilder();
+
+    // Add states
+    stateMachineBuilder.addState(State.READY, "The stage has been created.");
+    stateMachineBuilder.addState(State.EXECUTING, "The stage is executing (with its task groups being scheduled).");
+    stateMachineBuilder.addState(State.COMPLETE, "All of this stage's task groups have completed.");
+    stateMachineBuilder.addState(State.FAILED, "Stage failed.");
+
+    // Add transitions
+    stateMachineBuilder.addTransition(State.READY, State.EXECUTING,
+        "Begin executing!");
+    stateMachineBuilder.addTransition(State.EXECUTING, State.COMPLETE,
+        "All task groups complete");
+
+    stateMachineBuilder.addTransition(State.READY, State.FAILED,
+        "Master failure");
+    stateMachineBuilder.addTransition(State.EXECUTING, State.FAILED,
+        "Executor failure");
+
+    stateMachineBuilder.setInitialState(State.READY);
+
+    return stateMachineBuilder.build();
+  }
+
+  /**
+   * Stage states.
+   */
+  public enum State {
+    READY,
+    EXECUTING,
+    COMPLETE,
+    FAILED
+  }
+}

--- a/src/main/java/edu/snu/vortex/runtime/common/state/TaskGroupState.java
+++ b/src/main/java/edu/snu/vortex/runtime/common/state/TaskGroupState.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2017 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.vortex.runtime.common.state;
+
+import edu.snu.vortex.utils.StateMachine;
+
+/**
+ * Represents the states and their transitions of a {@link edu.snu.vortex.runtime.common.plan.physical.TaskGroup}.
+ */
+public final class TaskGroupState {
+  private final StateMachine stateMachine;
+
+  public TaskGroupState() {
+    stateMachine = buildTaskGroupStateMachine();
+  }
+
+  private StateMachine buildTaskGroupStateMachine() {
+    final StateMachine.Builder stateMachineBuilder = StateMachine.newBuilder();
+
+    // Add states
+    stateMachineBuilder.addState(State.READY, "The task group has been created.");
+    stateMachineBuilder.addState(State.SCHEDULED_TO_EXECUTOR,
+        "The task group has been scheduled to executor from master.");
+    stateMachineBuilder.addState(State.EXECUTING, "The task group is executing (with one of its tasks).");
+    stateMachineBuilder.addState(State.COMPLETE, "All of this task group's tasks have completed.");
+    stateMachineBuilder.addState(State.FAILED, "Task Group failed.");
+
+    // Add transitions
+    stateMachineBuilder.addTransition(State.READY, State.SCHEDULED_TO_EXECUTOR,
+        "Scheduling to executor");
+    stateMachineBuilder.addTransition(State.SCHEDULED_TO_EXECUTOR, State.EXECUTING,
+        "Begin executing!");
+    stateMachineBuilder.addTransition(State.EXECUTING, State.COMPLETE,
+        "All tasks complete");
+
+    stateMachineBuilder.addTransition(State.READY, State.FAILED,
+        "Master failure");
+    stateMachineBuilder.addTransition(State.SCHEDULED_TO_EXECUTOR, State.FAILED,
+        "Executor failure");
+    stateMachineBuilder.addTransition(State.EXECUTING, State.FAILED,
+        "Executor failure");
+
+    stateMachineBuilder.setInitialState(State.READY);
+
+    return stateMachineBuilder.build();
+  }
+
+  /**
+   * Task Group states.
+   */
+  public enum State {
+    READY,
+    SCHEDULED_TO_EXECUTOR,
+    EXECUTING,
+    COMPLETE,
+    FAILED
+  }
+}

--- a/src/main/java/edu/snu/vortex/runtime/common/state/TaskState.java
+++ b/src/main/java/edu/snu/vortex/runtime/common/state/TaskState.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2017 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.vortex.runtime.common.state;
+
+import edu.snu.vortex.utils.StateMachine;
+
+/**
+ * Represents the states and their transitions of a {@link edu.snu.vortex.runtime.common.plan.physical.Task}.
+ */
+public final class TaskState {
+  private final StateMachine stateMachine;
+
+  public TaskState() {
+    stateMachine = buildTaskStateMachine();
+  }
+
+  private StateMachine buildTaskStateMachine() {
+    final StateMachine.Builder stateMachineBuilder = StateMachine.newBuilder();
+
+    // Add states
+    stateMachineBuilder.addState(State.READY, "The task has been created.");
+    stateMachineBuilder.addState(State.SCHEDULED_TO_EXECUTOR, "The task has been scheduled to executor from master.");
+    stateMachineBuilder.addState(State.SCHEDULED_IN_EXECUTOR, "The task has been scheduled in its executor.");
+    stateMachineBuilder.addState(State.EXECUTING, "The task is executing.");
+    stateMachineBuilder.addState(State.COMPUTED, "The task's operation has been executed/computed.");
+    stateMachineBuilder.addState(State.OUTPUT_COMMITTED, "The task's output has been committed.");
+    stateMachineBuilder.addState(State.COMPLETE, "The task's execution is complete with its output committed.");
+    stateMachineBuilder.addState(State.FAILED, "Task failed.");
+
+    // Add transitions
+    stateMachineBuilder.addTransition(State.READY, State.SCHEDULED_TO_EXECUTOR,
+        "Scheduling to executor");
+    stateMachineBuilder.addTransition(State.SCHEDULED_TO_EXECUTOR, State.SCHEDULED_IN_EXECUTOR,
+        "Scheduling for execution");
+    stateMachineBuilder.addTransition(State.SCHEDULED_IN_EXECUTOR, State.EXECUTING,
+        "Begin executing!");
+    stateMachineBuilder.addTransition(State.EXECUTING, State.COMPUTED,
+        "Task computed");
+    stateMachineBuilder.addTransition(State.COMPUTED, State.OUTPUT_COMMITTED,
+        "Output written out");
+    stateMachineBuilder.addTransition(State.OUTPUT_COMMITTED, State.COMPLETE,
+        "Task is complete");
+
+    stateMachineBuilder.addTransition(State.READY, State.FAILED,
+        "Master failure");
+    stateMachineBuilder.addTransition(State.SCHEDULED_TO_EXECUTOR, State.FAILED,
+        "Executor failure");
+    stateMachineBuilder.addTransition(State.SCHEDULED_IN_EXECUTOR, State.FAILED,
+        "Executor failure");
+    stateMachineBuilder.addTransition(State.EXECUTING, State.FAILED,
+        "Executor failure");
+    stateMachineBuilder.addTransition(State.COMPUTED, State.FAILED,
+        "Executor failure");
+    stateMachineBuilder.addTransition(State.OUTPUT_COMMITTED, State.FAILED,
+        "Executor failure");
+
+    stateMachineBuilder.setInitialState(State.READY);
+
+    return stateMachineBuilder.build();
+  }
+
+  /**
+   * Task states.
+   */
+  public enum State {
+    READY,
+    SCHEDULED_TO_EXECUTOR,
+    SCHEDULED_IN_EXECUTOR,
+    EXECUTING,
+    COMPUTED,
+    OUTPUT_COMMITTED,
+    COMPLETE,
+    FAILED
+  }
+}


### PR DESCRIPTION
Resolves #86 .

This PR introduces Job, Stage, Task Group, Task states of the physical plan executing in `Runtime`.

State transitions have been added, but defining the triggering events for the transitions is in progress.
Complete state transition diagrams will be incrementally changed with #83 , #93 , #88  and uploaded with the final PR that resolves the 3 issues.