### PR TITLE
[VORTEX-167] Instructions/Scripts for DAG visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,4 @@ Vortex is a data-processing system composed of modular components.
 * `$ java -cp target/vortex-0.1-SNAPSHOT-shaded.jar edu.snu.vortex.compiler.optimizer.examples.MapReduce`
 
 ## DAG Visualization
-You can visualize a DAG using the JSON representation of it.
-
-### Requirements
-* Python 3 interpreter (3.5 or later version is recommended)
-* Graphviz
-
-### Howto
-Execute `./bin/json2png.py` and type in the JSON string, or save JSON in another file and execute `./bin/json2png.py < ./path/to/json`.
+You can visualize a DAG using the JSON representation of it, using [online visualizer](https://service.jangho.kr/vortex-dag/).

--- a/bin/json2dot.py
+++ b/bin/json2dot.py
@@ -15,13 +15,14 @@
 # limitations under the License.
 #
 
+'''
+json2dot.py: Generates Graphviz representation of Vortex DAG::toString
+This file is used as backend for https://service.jangho.kr/vortex-dag
+'''
+
 import sys
 import json
 import re
-import uuid
-from subprocess import Popen, PIPE, run
-from shutil import which
-from os import makedirs
 
 nextIdx = 0
 
@@ -31,6 +32,10 @@ def getIdx():
     return nextIdx
 
 class DAG:
+    '''
+    A class for converting DAG to Graphviz representation.
+    JSON representation should be formatted like what toString method in DAG.java does.
+    '''
     def __init__(self, dag):
         self.vertices = {}
         self.edges = []
@@ -262,16 +267,4 @@ def jsonToDot(dagJSON):
     return 'digraph dag {compound=true; nodesep=1.0; forcelabels=true;' + DAG(dagJSON).dot + '}'
 
 if __name__ == "__main__":
-    dot = jsonToDot(json.loads(sys.stdin.read()))
-    filename = './target/json2png/{}.png'.format(uuid.uuid4().hex)
-    makedirs('./target/json2png', exist_ok=True)
-    p = Popen(['dot', '-Tpng', '-o', filename], stdin=PIPE, stdout=PIPE, stderr=PIPE)
-    stderr = str(p.communicate(bytes(dot, 'utf-8'))[1], 'utf-8')
-    if p.returncode != 0:
-        print(stderr, file=sys.stderr)
-        sys.exit(p.returncode)
-    if which('open') is not None:
-        sys.exit(run(['open', filename]).returncode)
-    if which('xdg-open') is not None:
-        sys.exit(run(['xdg-open', filename]).returncode)
-    print('PNG saved to {}'.format(filename))
+    print(jsonToDot(json.loads(sys.stdin.read())))


### PR DESCRIPTION
Resolves #167 

## Tests needed!

macOS users, please test whether `./bin/json2png.py` automatically opens the generated png file with your default image viewer. In freedesktop-compliant environment like GNOME, I can use `xdg-open` but I don't exactly know macOS equivalent of it.

## TODO: 4096 characters

Terminal canonical mode will now allow more or equal than 4096 characters in one line. [ref](http://stackoverflow.com/questions/18015137/linux-terminal-input-reading-user-input-from-terminal-truncating-lines-at-4095) We'd better `DAG::toString` to generate json that spans over multiple lines.

Meanwhile, please save JSON representation to another file and execute `./bin/json2png.py < ./path/to/json`.