### PR TITLE
[Vortex-138] Speed Up Maven Builds and Tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,22 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.20</version>
+                <configuration>
+                    <reuseForks>true</reuseForks>
+                    <forkCount>0.5C</forkCount>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit47</artifactId>
+                        <version>2.20</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>2.3</version>
                 <executions>

--- a/src/main/java/edu/snu/vortex/runtime/master/VortexDriver.java
+++ b/src/main/java/edu/snu/vortex/runtime/master/VortexDriver.java
@@ -211,7 +211,6 @@ public final class VortexDriver {
     }
   }
 
-
   private Configuration getExecutorConfiguration(final String executorId) {
     final Configuration executorConfiguration = JobConf.EXECUTOR_CONF
         .set(JobConf.EXECUTOR_ID, executorId)

--- a/src/test/java/edu/snu/vortex/examples/beam/AlternatingLeastSquareTest.java
+++ b/src/test/java/edu/snu/vortex/examples/beam/AlternatingLeastSquareTest.java
@@ -18,15 +18,10 @@ package edu.snu.vortex.examples.beam;
 import edu.snu.vortex.client.JobLauncher;
 import edu.snu.vortex.compiler.TestUtil;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 /**
  * Test Alternating Least Square program with JobLauncher.
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(JobLauncher.class)
 public final class AlternatingLeastSquareTest {
   private static final String als = "edu.snu.vortex.examples.beam.AlternatingLeastSquare";
   private static final String optimizationPolicy = "pado";

--- a/src/test/java/edu/snu/vortex/examples/beam/BroadcastTest.java
+++ b/src/test/java/edu/snu/vortex/examples/beam/BroadcastTest.java
@@ -18,15 +18,10 @@ package edu.snu.vortex.examples.beam;
 import edu.snu.vortex.client.JobLauncher;
 import edu.snu.vortex.compiler.TestUtil;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 /**
  * Test Broadcast program with JobLauncher.
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(JobLauncher.class)
 public final class BroadcastTest {
   private final String broadcast = "edu.snu.vortex.examples.beam.Broadcast";
   private final String optimizationPolicy = "pado";

--- a/src/test/java/edu/snu/vortex/examples/beam/MapReduceDisaggregationTest.java
+++ b/src/test/java/edu/snu/vortex/examples/beam/MapReduceDisaggregationTest.java
@@ -18,15 +18,10 @@ package edu.snu.vortex.examples.beam;
 import edu.snu.vortex.client.JobLauncher;
 import edu.snu.vortex.compiler.TestUtil;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 /**
  * Test MapReduce program with JobLauncher.
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(JobLauncher.class)
 public final class MapReduceDisaggregationTest {
   private final String mapReduce = "edu.snu.vortex.examples.beam.MapReduce";
   private final String optimizationPolicy = "disaggregation";

--- a/src/test/java/edu/snu/vortex/examples/beam/MapReduceTest.java
+++ b/src/test/java/edu/snu/vortex/examples/beam/MapReduceTest.java
@@ -18,15 +18,10 @@ package edu.snu.vortex.examples.beam;
 import edu.snu.vortex.client.JobLauncher;
 import edu.snu.vortex.compiler.TestUtil;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 /**
  * Test MapReduce program with JobLauncher.
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(JobLauncher.class)
 public final class MapReduceTest {
   private final String mapReduce = "edu.snu.vortex.examples.beam.MapReduce";
   private final String optimizationPolicy = "pado";

--- a/src/test/java/edu/snu/vortex/examples/beam/MultinomialLogisticRegressionTest.java
+++ b/src/test/java/edu/snu/vortex/examples/beam/MultinomialLogisticRegressionTest.java
@@ -18,15 +18,10 @@ package edu.snu.vortex.examples.beam;
 import edu.snu.vortex.client.JobLauncher;
 import edu.snu.vortex.compiler.TestUtil;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 /**
  * Testing Multinomial Logistic Regressions with JobLauncher.
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(JobLauncher.class)
 public final class MultinomialLogisticRegressionTest {
   private static final String mlr = "edu.snu.vortex.examples.beam.MultinomialLogisticRegression";
   private static final String optimizationPolicy = "pado";


### PR DESCRIPTION
This PR:

- parallelizes the maven build with surefire by forking multiple JVMs for test

(At now, It only forks one JVM per two CPU cores. This is because I've experienced an error related with maximum opened file numbers in OS side, when the parallelization was increased.)

resolves #138 