### PR TITLE
[Vortex-227] Separate Integration Tests from Unit Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,14 @@
 # Vortex 
 [![Build Status](http://cmscluster.snu.ac.kr:8080/jenkins/buildStatus/icon?job=Vortex-master)](http://cmscluster.snu.ac.kr:8080/jenkins/job/Vortex-master/)
 
-Vortex is a data-processing system composed of modular components.
-
-## Components
-* Compiler: Compiles a user program into an executable for the Engine.
-* Engine: Physically executes the user program.
-
 ## Requirements
 * Java 8
 * Maven
 * Protobuf 3.2.0
+
+## Installing Vortex
+* Run all tests and install: `mvn clean install -T 2C`
+* Run only unit tests and install: `mvn clean install -DskipITs -T 2C`
 
 ## Examples
 ```bash

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,19 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.20</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>2.3</version>
                 <executions>

--- a/src/test/java/edu/snu/vortex/compiler/TestUtil.java
+++ b/src/test/java/edu/snu/vortex/compiler/TestUtil.java
@@ -20,9 +20,9 @@ import edu.snu.vortex.client.JobLauncher;
 import edu.snu.vortex.compiler.frontend.Frontend;
 import edu.snu.vortex.compiler.frontend.beam.BeamFrontend;
 import edu.snu.vortex.compiler.ir.*;
-import edu.snu.vortex.examples.beam.AlternatingLeastSquareTest;
+import edu.snu.vortex.examples.beam.AlternatingLeastSquareITCase;
 import edu.snu.vortex.examples.beam.ArgBuilder;
-import edu.snu.vortex.examples.beam.MultinomialLogisticRegressionTest;
+import edu.snu.vortex.examples.beam.MultinomialLogisticRegressionITCase;
 import edu.snu.vortex.utils.dag.DAG;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.io.BoundedSource;
@@ -30,11 +30,7 @@ import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.Injector;
 import org.apache.reef.tang.Tang;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -47,7 +43,7 @@ public final class TestUtil {
 
   public static DAG<IRVertex, IREdge> compileALSDAG() throws Exception {
     final Frontend beamFrontend = new BeamFrontend();
-    final ArgBuilder alsArgBuilder = AlternatingLeastSquareTest.builder;
+    final ArgBuilder alsArgBuilder = AlternatingLeastSquareITCase.builder;
     final Configuration configuration = JobLauncher.getJobConf(alsArgBuilder.build());
     final Injector injector = Tang.Factory.getTang().newInjector(configuration);
     final String className = injector.getNamedInstance(JobConf.UserMainClass.class);
@@ -58,7 +54,7 @@ public final class TestUtil {
 
   public static DAG<IRVertex, IREdge> compileMLRDAG() throws Exception {
     final Frontend beamFrontend = new BeamFrontend();
-    final ArgBuilder alsArgBuilder = MultinomialLogisticRegressionTest.builder;
+    final ArgBuilder alsArgBuilder = MultinomialLogisticRegressionITCase.builder;
     final Configuration configuration = JobLauncher.getJobConf(alsArgBuilder.build());
     final Injector injector = Tang.Factory.getTang().newInjector(configuration);
     final String className = injector.getNamedInstance(JobConf.UserMainClass.class);

--- a/src/test/java/edu/snu/vortex/examples/beam/AlternatingLeastSquareITCase.java
+++ b/src/test/java/edu/snu/vortex/examples/beam/AlternatingLeastSquareITCase.java
@@ -23,24 +23,23 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 /**
- * Testing Multinomial Logistic Regressions with JobLauncher.
+ * Test Alternating Least Square program with JobLauncher.
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(JobLauncher.class)
-public final class MultinomialLogisticRegressionTest {
-  private static final String mlr = "edu.snu.vortex.examples.beam.MultinomialLogisticRegression";
+public final class AlternatingLeastSquareITCase {
+  private static final String als = "edu.snu.vortex.examples.beam.AlternatingLeastSquare";
   private static final String optimizationPolicy = "pado";
-  private static final String input = TestUtil.rootDir + "/src/main/resources/sample_input_mlr";
-  private static final String numFeatures = "100";
-  private static final String numClasses = "5";
+  private static final String input = TestUtil.rootDir + "/src/main/resources/sample_input_als";
+  private static final String numFeatures = "10";
   private static final String numIteration = "3";
   private static final String dagDirectory = "./dag";
 
   public static final ArgBuilder builder = new ArgBuilder()
-      .addJobId(MultinomialLogisticRegressionTest.class.getSimpleName())
-      .addUserMain(mlr)
+      .addJobId(AlternatingLeastSquareITCase.class.getSimpleName())
+      .addUserMain(als)
       .addOptimizationPolicy(optimizationPolicy)
-      .addUserArgs(input, numFeatures, numClasses, numIteration)
+      .addUserArgs(input, numFeatures, numIteration)
       .addDAGDirectory(dagDirectory);
 
   @Test

--- a/src/test/java/edu/snu/vortex/examples/beam/BroadcastITCase.java
+++ b/src/test/java/edu/snu/vortex/examples/beam/BroadcastITCase.java
@@ -27,7 +27,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(JobLauncher.class)
-public final class BroadcastTest {
+public final class BroadcastITCase {
   private final String broadcast = "edu.snu.vortex.examples.beam.Broadcast";
   private final String optimizationPolicy = "pado";
   private final String input = TestUtil.rootDir + "/src/main/resources/sample_input_mr";
@@ -37,7 +37,7 @@ public final class BroadcastTest {
   @Test
   public void test() throws Exception {
     final ArgBuilder builder = new ArgBuilder()
-        .addJobId(BroadcastTest.class.getSimpleName())
+        .addJobId(BroadcastITCase.class.getSimpleName())
         .addUserMain(broadcast)
         .addOptimizationPolicy(optimizationPolicy)
         .addUserArgs(input, output)

--- a/src/test/java/edu/snu/vortex/examples/beam/MapReduceDisaggregationITCase.java
+++ b/src/test/java/edu/snu/vortex/examples/beam/MapReduceDisaggregationITCase.java
@@ -23,27 +23,25 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 /**
- * Test Alternating Least Square program with JobLauncher.
+ * Test MapReduce program with JobLauncher.
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(JobLauncher.class)
-public final class AlternatingLeastSquareTest {
-  private static final String als = "edu.snu.vortex.examples.beam.AlternatingLeastSquare";
-  private static final String optimizationPolicy = "pado";
-  private static final String input = TestUtil.rootDir + "/src/main/resources/sample_input_als";
-  private static final String numFeatures = "10";
-  private static final String numIteration = "3";
-  private static final String dagDirectory = "./dag";
-
-  public static final ArgBuilder builder = new ArgBuilder()
-      .addJobId(AlternatingLeastSquareTest.class.getSimpleName())
-      .addUserMain(als)
-      .addOptimizationPolicy(optimizationPolicy)
-      .addUserArgs(input, numFeatures, numIteration)
-      .addDAGDirectory(dagDirectory);
+public final class MapReduceDisaggregationITCase {
+  private final String mapReduce = "edu.snu.vortex.examples.beam.MapReduce";
+  private final String optimizationPolicy = "disaggregation";
+  private final String input = TestUtil.rootDir + "/src/main/resources/sample_input_mr";
+  private final String output = TestUtil.rootDir + "/src/main/resources/sample_output";
+  private final String dagDirectory = "./dag";
 
   @Test
   public void test() throws Exception {
+    final ArgBuilder builder = new ArgBuilder()
+        .addJobId(MapReduceDisaggregationITCase.class.getSimpleName())
+        .addUserMain(mapReduce)
+        .addOptimizationPolicy(optimizationPolicy)
+        .addUserArgs(input, output)
+        .addDAGDirectory(dagDirectory);
     JobLauncher.main(builder.build());
   }
 }

--- a/src/test/java/edu/snu/vortex/examples/beam/MapReduceITCase.java
+++ b/src/test/java/edu/snu/vortex/examples/beam/MapReduceITCase.java
@@ -27,9 +27,9 @@ import org.powermock.modules.junit4.PowerMockRunner;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(JobLauncher.class)
-public final class MapReduceDisaggregationTest {
+public final class MapReduceITCase {
   private final String mapReduce = "edu.snu.vortex.examples.beam.MapReduce";
-  private final String optimizationPolicy = "disaggregation";
+  private final String optimizationPolicy = "pado";
   private final String input = TestUtil.rootDir + "/src/main/resources/sample_input_mr";
   private final String output = TestUtil.rootDir + "/src/main/resources/sample_output";
   private final String dagDirectory = "./dag";
@@ -37,7 +37,7 @@ public final class MapReduceDisaggregationTest {
   @Test
   public void test() throws Exception {
     final ArgBuilder builder = new ArgBuilder()
-        .addJobId(MapReduceDisaggregationTest.class.getSimpleName())
+        .addJobId(MapReduceITCase.class.getSimpleName())
         .addUserMain(mapReduce)
         .addOptimizationPolicy(optimizationPolicy)
         .addUserArgs(input, output)

--- a/src/test/java/edu/snu/vortex/examples/beam/MultinomialLogisticRegressionITCase.java
+++ b/src/test/java/edu/snu/vortex/examples/beam/MultinomialLogisticRegressionITCase.java
@@ -23,25 +23,28 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 /**
- * Test MapReduce program with JobLauncher.
+ * Testing Multinomial Logistic Regressions with JobLauncher.
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(JobLauncher.class)
-public final class MapReduceTest {
-  private final String mapReduce = "edu.snu.vortex.examples.beam.MapReduce";
-  private final String optimizationPolicy = "pado";
-  private final String input = TestUtil.rootDir + "/src/main/resources/sample_input_mr";
-  private final String output = TestUtil.rootDir + "/src/main/resources/sample_output";
-  private final String dagDirectory = "./dag";
+public final class MultinomialLogisticRegressionITCase {
+  private static final String mlr = "edu.snu.vortex.examples.beam.MultinomialLogisticRegression";
+  private static final String optimizationPolicy = "pado";
+  private static final String input = TestUtil.rootDir + "/src/main/resources/sample_input_mlr";
+  private static final String numFeatures = "100";
+  private static final String numClasses = "5";
+  private static final String numIteration = "3";
+  private static final String dagDirectory = "./dag";
+
+  public static final ArgBuilder builder = new ArgBuilder()
+      .addJobId(MultinomialLogisticRegressionITCase.class.getSimpleName())
+      .addUserMain(mlr)
+      .addOptimizationPolicy(optimizationPolicy)
+      .addUserArgs(input, numFeatures, numClasses, numIteration)
+      .addDAGDirectory(dagDirectory);
 
   @Test
   public void test() throws Exception {
-    final ArgBuilder builder = new ArgBuilder()
-        .addJobId(MapReduceTest.class.getSimpleName())
-        .addUserMain(mapReduce)
-        .addOptimizationPolicy(optimizationPolicy)
-        .addUserArgs(input, output)
-        .addDAGDirectory(dagDirectory);
     JobLauncher.main(builder.build());
   }
 }


### PR DESCRIPTION
Closes #227 
* Introduce the `failsafe` plugin
* Rename integration tests to be identified by the `failsafe` plugin
* Add instructions on skipping integration tests

@jooykim Please let me know if this solves the problem for the time being. 😁 