### PR TITLE
[Minor] Change Default DAG directory

### DIFF
--- a/src/main/java/edu/snu/vortex/client/JobConf.java
+++ b/src/main/java/edu/snu/vortex/client/JobConf.java
@@ -38,7 +38,7 @@ public final class JobConf extends ConfigurationModuleBuilder {
   /**
    * Directory to store JSON representation of intermediate DAGs.
    */
-  @NamedParameter(doc = "Directory to store intermediate DAGs", short_name = "dag_dir", default_value = "./target/dag")
+  @NamedParameter(doc = "Directory to store intermediate DAGs", short_name = "dag_dir", default_value = "./dag")
   public final class DAGDirectory implements Name<String> {
   }
 


### PR DESCRIPTION
Change from `./target/dag` to `./dag`, now that Vortex runs on REEF and the master(driver) has its own directory for logs and etc.

@seojangho Please check and merge. 😄 