### PR TITLE
[Minor] Fix Pado Pass to Use LocalFile for Push Edges

### DIFF
--- a/src/main/java/edu/snu/vortex/compiler/optimizer/passes/PadoEdgePass.java
+++ b/src/main/java/edu/snu/vortex/compiler/optimizer/passes/PadoEdgePass.java
@@ -33,7 +33,7 @@ public final class PadoEdgePass implements Pass {
       if (!inEdges.isEmpty()) {
         inEdges.forEach(edge -> {
           if (fromTransientToReserved(edge)) {
-            edge.setAttr(Attribute.Key.ChannelDataPlacement, Attribute.Memory);
+            edge.setAttr(Attribute.Key.ChannelDataPlacement, Attribute.LocalFile);
             edge.setAttr(Attribute.Key.ChannelTransferPolicy, Attribute.Push);
           } else if (fromReservedToTransient(edge)) {
             edge.setAttr(Attribute.Key.ChannelDataPlacement, Attribute.LocalFile);

--- a/src/test/java/edu/snu/vortex/compiler/optimizer/passes/PadoPassTest.java
+++ b/src/test/java/edu/snu/vortex/compiler/optimizer/passes/PadoPassTest.java
@@ -59,7 +59,7 @@ public class PadoPassTest {
     final IRVertex vertex6 = processedDAG.getTopologicalSort().get(2);
     assertEquals(Attribute.Reserved, vertex6.getAttr(Attribute.Key.Placement));
     processedDAG.getIncomingEdgesOf(vertex6).forEach(irEdge -> {
-      assertEquals(Attribute.Memory, irEdge.getAttr(Attribute.Key.ChannelDataPlacement));
+      assertEquals(Attribute.LocalFile, irEdge.getAttr(Attribute.Key.ChannelDataPlacement));
       assertEquals(Attribute.Push, irEdge.getAttr(Attribute.Key.ChannelTransferPolicy));
     });
 


### PR DESCRIPTION
This PR temporally resolves the OOM issue during 12GB Pado MR with constrained resources.
It would be good to consider the stage-level garbage collection / partition GC upon consumption.