### PR TITLE
[Minor] Fix BatchSchedulerTest mocking problem

### DIFF
--- a/src/test/java/edu/snu/vortex/common/PairTest.java
+++ b/src/test/java/edu/snu/vortex/common/PairTest.java
@@ -15,7 +15,7 @@
  */
 package edu.snu.vortex.common;
 
-import edu.snu.vortex.compiler.TestUtil;
+import edu.snu.vortex.compiler.CompilerTestUtil;
 import edu.snu.vortex.compiler.frontend.beam.BoundedSourceVertex;
 import edu.snu.vortex.compiler.ir.IRVertex;
 import org.junit.Test;
@@ -28,8 +28,8 @@ import static org.junit.Assert.assertEquals;
 public class PairTest {
   final Object leftObject = new Object();
   final Object rightObject = new Object();
-  private final IRVertex leftSource = new BoundedSourceVertex<>(new TestUtil.EmptyBoundedSource("leftSource"));
-  private final IRVertex rightSource = new BoundedSourceVertex<>(new TestUtil.EmptyBoundedSource("rightSource"));
+  private final IRVertex leftSource = new BoundedSourceVertex<>(new CompilerTestUtil.EmptyBoundedSource("leftSource"));
+  private final IRVertex rightSource = new BoundedSourceVertex<>(new CompilerTestUtil.EmptyBoundedSource("rightSource"));
 
   @Test
   public void testPair() {

--- a/src/test/java/edu/snu/vortex/compiler/CompilerTestUtil.java
+++ b/src/test/java/edu/snu/vortex/compiler/CompilerTestUtil.java
@@ -37,7 +37,7 @@ import java.util.List;
 /**
  * Utility methods for tests.
  */
-public final class TestUtil {
+public final class CompilerTestUtil {
   public static String rootDir = System.getProperty("user.dir");
 
   public static DAG<IRVertex, IREdge> compileMRDAG() throws Exception {

--- a/src/test/java/edu/snu/vortex/compiler/backend/vortex/VortexBackendTest.java
+++ b/src/test/java/edu/snu/vortex/compiler/backend/vortex/VortexBackendTest.java
@@ -15,7 +15,7 @@
  */
 package edu.snu.vortex.compiler.backend.vortex;
 
-import edu.snu.vortex.compiler.TestUtil;
+import edu.snu.vortex.compiler.CompilerTestUtil;
 import edu.snu.vortex.compiler.backend.Backend;
 import edu.snu.vortex.common.coder.Coder;
 import edu.snu.vortex.compiler.frontend.beam.BoundedSourceVertex;
@@ -35,10 +35,10 @@ import static org.junit.Assert.assertEquals;
  * Test Vortex Backend.
  */
 public final class VortexBackendTest<I, O> {
-  private final IRVertex source = new BoundedSourceVertex<>(new TestUtil.EmptyBoundedSource("Source"));
-  private final IRVertex map1 = new OperatorVertex(new TestUtil.EmptyTransform("MapElements"));
-  private final IRVertex groupByKey = new OperatorVertex(new TestUtil.EmptyTransform("GroupByKey"));
-  private final IRVertex combine = new OperatorVertex(new TestUtil.EmptyTransform("Combine"));
+  private final IRVertex source = new BoundedSourceVertex<>(new CompilerTestUtil.EmptyBoundedSource("Source"));
+  private final IRVertex map1 = new OperatorVertex(new CompilerTestUtil.EmptyTransform("MapElements"));
+  private final IRVertex groupByKey = new OperatorVertex(new CompilerTestUtil.EmptyTransform("GroupByKey"));
+  private final IRVertex combine = new OperatorVertex(new CompilerTestUtil.EmptyTransform("Combine"));
   private final IRVertex map2 = new OperatorVertex(new DoTransform(null, null));
 
   private final DAGBuilder<IRVertex, IREdge> builder = new DAGBuilder<>();

--- a/src/test/java/edu/snu/vortex/compiler/frontend/beam/BeamFrontendALSTest.java
+++ b/src/test/java/edu/snu/vortex/compiler/frontend/beam/BeamFrontendALSTest.java
@@ -16,7 +16,7 @@
 package edu.snu.vortex.compiler.frontend.beam;
 
 import edu.snu.vortex.client.JobLauncher;
-import edu.snu.vortex.compiler.TestUtil;
+import edu.snu.vortex.compiler.CompilerTestUtil;
 import edu.snu.vortex.compiler.ir.IREdge;
 import edu.snu.vortex.compiler.ir.IRVertex;
 import edu.snu.vortex.common.dag.DAG;
@@ -35,7 +35,7 @@ import static org.junit.Assert.assertEquals;
 public final class BeamFrontendALSTest {
   @Test
   public void testALSDAG() throws Exception {
-    final DAG<IRVertex, IREdge> producedDAG = TestUtil.compileALSDAG();
+    final DAG<IRVertex, IREdge> producedDAG = CompilerTestUtil.compileALSDAG();
 
     assertEquals(producedDAG.getTopologicalSort(), producedDAG.getTopologicalSort());
     assertEquals(20, producedDAG.getVertices().size());

--- a/src/test/java/edu/snu/vortex/compiler/frontend/beam/BeamFrontendMLRTest.java
+++ b/src/test/java/edu/snu/vortex/compiler/frontend/beam/BeamFrontendMLRTest.java
@@ -16,7 +16,7 @@
 package edu.snu.vortex.compiler.frontend.beam;
 
 import edu.snu.vortex.client.JobLauncher;
-import edu.snu.vortex.compiler.TestUtil;
+import edu.snu.vortex.compiler.CompilerTestUtil;
 import edu.snu.vortex.compiler.ir.IREdge;
 import edu.snu.vortex.compiler.ir.IRVertex;
 import edu.snu.vortex.common.dag.DAG;
@@ -35,7 +35,7 @@ import static org.junit.Assert.assertEquals;
 public class BeamFrontendMLRTest {
   @Test
   public void testMLRDAG() throws Exception {
-    final DAG<IRVertex, IREdge> producedDAG = TestUtil.compileMLRDAG();
+    final DAG<IRVertex, IREdge> producedDAG = CompilerTestUtil.compileMLRDAG();
 
     assertEquals(producedDAG.getTopologicalSort(), producedDAG.getTopologicalSort());
     assertEquals(33, producedDAG.getVertices().size());

--- a/src/test/java/edu/snu/vortex/compiler/ir/LoopVertexTest.java
+++ b/src/test/java/edu/snu/vortex/compiler/ir/LoopVertexTest.java
@@ -15,7 +15,7 @@
  */
 package edu.snu.vortex.compiler.ir;
 
-import edu.snu.vortex.compiler.TestUtil;
+import edu.snu.vortex.compiler.CompilerTestUtil;
 import edu.snu.vortex.common.coder.Coder;
 import edu.snu.vortex.compiler.frontend.beam.BoundedSourceVertex;
 import edu.snu.vortex.compiler.frontend.beam.transform.DoTransform;
@@ -39,10 +39,10 @@ public class LoopVertexTest {
   private DAG<IRVertex, IREdge> originalDAG;
   private DAG<IRVertex, IREdge> newDAG;
 
-  private final IRVertex source = new BoundedSourceVertex<>(new TestUtil.EmptyBoundedSource("Source"));
-  private final IRVertex map1 = new OperatorVertex(new TestUtil.EmptyTransform("MapElements"));
-  private final IRVertex groupByKey = new OperatorVertex(new TestUtil.EmptyTransform("GroupByKey"));
-  private final IRVertex combine = new OperatorVertex(new TestUtil.EmptyTransform("Combine"));
+  private final IRVertex source = new BoundedSourceVertex<>(new CompilerTestUtil.EmptyBoundedSource("Source"));
+  private final IRVertex map1 = new OperatorVertex(new CompilerTestUtil.EmptyTransform("MapElements"));
+  private final IRVertex groupByKey = new OperatorVertex(new CompilerTestUtil.EmptyTransform("GroupByKey"));
+  private final IRVertex combine = new OperatorVertex(new CompilerTestUtil.EmptyTransform("Combine"));
   private final IRVertex map2 = new OperatorVertex(new DoTransform(null, null));
 
   @Before

--- a/src/test/java/edu/snu/vortex/compiler/ir/attribute/AttributeMapTest.java
+++ b/src/test/java/edu/snu/vortex/compiler/ir/attribute/AttributeMapTest.java
@@ -15,7 +15,7 @@
  */
 package edu.snu.vortex.compiler.ir.attribute;
 
-import edu.snu.vortex.compiler.TestUtil;
+import edu.snu.vortex.compiler.CompilerTestUtil;
 import edu.snu.vortex.common.coder.Coder;
 import edu.snu.vortex.compiler.frontend.beam.BoundedSourceVertex;
 import edu.snu.vortex.compiler.ir.IREdge;
@@ -31,8 +31,8 @@ import static org.junit.Assert.assertNull;
  * Test {@link AttributeMap}.
  */
 public class AttributeMapTest {
-  private final IRVertex source = new BoundedSourceVertex<>(new TestUtil.EmptyBoundedSource("Source"));
-  private final IRVertex destination = new OperatorVertex(new TestUtil.EmptyTransform("MapElements"));
+  private final IRVertex source = new BoundedSourceVertex<>(new CompilerTestUtil.EmptyBoundedSource("Source"));
+  private final IRVertex destination = new OperatorVertex(new CompilerTestUtil.EmptyTransform("MapElements"));
   private final IREdge edge = new IREdge(IREdge.Type.OneToOne, source, destination, Coder.DUMMY_CODER);
 
   private AttributeMap edgeMap;

--- a/src/test/java/edu/snu/vortex/compiler/optimizer/passes/DataSkewPassTest.java
+++ b/src/test/java/edu/snu/vortex/compiler/optimizer/passes/DataSkewPassTest.java
@@ -17,7 +17,7 @@ package edu.snu.vortex.compiler.optimizer.passes;
 
 import edu.snu.vortex.client.JobLauncher;
 import edu.snu.vortex.common.dag.DAG;
-import edu.snu.vortex.compiler.TestUtil;
+import edu.snu.vortex.compiler.CompilerTestUtil;
 import edu.snu.vortex.compiler.frontend.beam.transform.GroupByKeyTransform;
 import edu.snu.vortex.compiler.ir.MetricCollectionBarrierVertex;
 import edu.snu.vortex.compiler.ir.IREdge;
@@ -42,7 +42,7 @@ public class DataSkewPassTest {
 
   @Before
   public void setUp() throws Exception {
-    mrDAG = TestUtil.compileMRDAG();
+    mrDAG = CompilerTestUtil.compileMRDAG();
   }
 
   /**

--- a/src/test/java/edu/snu/vortex/compiler/optimizer/passes/DisaggregationPassTest.java
+++ b/src/test/java/edu/snu/vortex/compiler/optimizer/passes/DisaggregationPassTest.java
@@ -16,7 +16,7 @@
 package edu.snu.vortex.compiler.optimizer.passes;
 
 import edu.snu.vortex.client.JobLauncher;
-import edu.snu.vortex.compiler.TestUtil;
+import edu.snu.vortex.compiler.CompilerTestUtil;
 import edu.snu.vortex.compiler.ir.IREdge;
 import edu.snu.vortex.compiler.ir.IRVertex;
 import edu.snu.vortex.compiler.ir.attribute.Attribute;
@@ -39,7 +39,7 @@ public class DisaggregationPassTest {
 
   @Before
   public void setUp() throws Exception {
-    compiledDAG = TestUtil.compileALSDAG();
+    compiledDAG = CompilerTestUtil.compileALSDAG();
   }
 
   @Test

--- a/src/test/java/edu/snu/vortex/compiler/optimizer/passes/LoopGroupingPassTest.java
+++ b/src/test/java/edu/snu/vortex/compiler/optimizer/passes/LoopGroupingPassTest.java
@@ -16,7 +16,7 @@
 package edu.snu.vortex.compiler.optimizer.passes;
 
 import edu.snu.vortex.client.JobLauncher;
-import edu.snu.vortex.compiler.TestUtil;
+import edu.snu.vortex.compiler.CompilerTestUtil;
 import edu.snu.vortex.compiler.ir.IREdge;
 import edu.snu.vortex.compiler.ir.IRVertex;
 import edu.snu.vortex.common.dag.DAG;
@@ -38,7 +38,7 @@ public class LoopGroupingPassTest {
 
   @Before
   public void setUp() throws Exception {
-    compiledDAG = TestUtil.compileALSDAG();
+    compiledDAG = CompilerTestUtil.compileALSDAG();
   }
 
   @Test

--- a/src/test/java/edu/snu/vortex/compiler/optimizer/passes/LoopUnrollingPassTest.java
+++ b/src/test/java/edu/snu/vortex/compiler/optimizer/passes/LoopUnrollingPassTest.java
@@ -16,7 +16,7 @@
 package edu.snu.vortex.compiler.optimizer.passes;
 
 import edu.snu.vortex.client.JobLauncher;
-import edu.snu.vortex.compiler.TestUtil;
+import edu.snu.vortex.compiler.CompilerTestUtil;
 import edu.snu.vortex.compiler.ir.IREdge;
 import edu.snu.vortex.compiler.ir.IRVertex;
 import edu.snu.vortex.common.Pair;
@@ -43,7 +43,7 @@ public class LoopUnrollingPassTest {
 
   @Before
   public void setUp() throws Exception {
-    compiledDAG = TestUtil.compileALSDAG();
+    compiledDAG = CompilerTestUtil.compileALSDAG();
   }
 
   @Test

--- a/src/test/java/edu/snu/vortex/compiler/optimizer/passes/PadoPassTest.java
+++ b/src/test/java/edu/snu/vortex/compiler/optimizer/passes/PadoPassTest.java
@@ -16,7 +16,7 @@
 package edu.snu.vortex.compiler.optimizer.passes;
 
 import edu.snu.vortex.client.JobLauncher;
-import edu.snu.vortex.compiler.TestUtil;
+import edu.snu.vortex.compiler.CompilerTestUtil;
 import edu.snu.vortex.compiler.ir.IREdge;
 import edu.snu.vortex.compiler.ir.IRVertex;
 import edu.snu.vortex.compiler.ir.attribute.Attribute;
@@ -39,7 +39,7 @@ public class PadoPassTest {
 
   @Before
   public void setUp() throws Exception {
-    compiledDAG = TestUtil.compileALSDAG();
+    compiledDAG = CompilerTestUtil.compileALSDAG();
   }
 
   @Test

--- a/src/test/java/edu/snu/vortex/compiler/optimizer/passes/ParallelismPassTest.java
+++ b/src/test/java/edu/snu/vortex/compiler/optimizer/passes/ParallelismPassTest.java
@@ -16,7 +16,7 @@
 package edu.snu.vortex.compiler.optimizer.passes;
 
 import edu.snu.vortex.client.JobLauncher;
-import edu.snu.vortex.compiler.TestUtil;
+import edu.snu.vortex.compiler.CompilerTestUtil;
 import edu.snu.vortex.compiler.ir.IREdge;
 import edu.snu.vortex.compiler.ir.IRVertex;
 import edu.snu.vortex.compiler.ir.attribute.Attribute;
@@ -39,7 +39,7 @@ public class ParallelismPassTest {
 
   @Before
   public void setUp() throws Exception {
-    compiledDAG = TestUtil.compileALSDAG();
+    compiledDAG = CompilerTestUtil.compileALSDAG();
   }
 
   @Test

--- a/src/test/java/edu/snu/vortex/compiler/optimizer/passes/optimization/CommonSubexpressionEliminationPassTest.java
+++ b/src/test/java/edu/snu/vortex/compiler/optimizer/passes/optimization/CommonSubexpressionEliminationPassTest.java
@@ -16,7 +16,7 @@
 package edu.snu.vortex.compiler.optimizer.passes.optimization;
 
 import edu.snu.vortex.client.JobLauncher;
-import edu.snu.vortex.compiler.TestUtil;
+import edu.snu.vortex.compiler.CompilerTestUtil;
 import edu.snu.vortex.common.coder.Coder;
 import edu.snu.vortex.compiler.frontend.beam.BoundedSourceVertex;
 import edu.snu.vortex.compiler.frontend.beam.transform.DoTransform;
@@ -39,15 +39,15 @@ import static org.junit.Assert.assertEquals;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(JobLauncher.class)
 public class CommonSubexpressionEliminationPassTest {
-  private final IRVertex source = new BoundedSourceVertex<>(new TestUtil.EmptyBoundedSource("Source"));
-  private final IRVertex map1 = new OperatorVertex(new TestUtil.EmptyTransform("MapElements"));
-  private final IRVertex groupByKey = new OperatorVertex(new TestUtil.EmptyTransform("GroupByKey"));
-  private final IRVertex combine = new OperatorVertex(new TestUtil.EmptyTransform("Combine"));
+  private final IRVertex source = new BoundedSourceVertex<>(new CompilerTestUtil.EmptyBoundedSource("Source"));
+  private final IRVertex map1 = new OperatorVertex(new CompilerTestUtil.EmptyTransform("MapElements"));
+  private final IRVertex groupByKey = new OperatorVertex(new CompilerTestUtil.EmptyTransform("GroupByKey"));
+  private final IRVertex combine = new OperatorVertex(new CompilerTestUtil.EmptyTransform("Combine"));
   private final IRVertex map2 = new OperatorVertex(new DoTransform(null, null));
 
   private final IRVertex map1clone = map1.getClone();
-  private final IRVertex groupByKey2 = new OperatorVertex(new TestUtil.EmptyTransform("GroupByKey2"));
-  private final IRVertex combine2 = new OperatorVertex(new TestUtil.EmptyTransform("Combine2"));
+  private final IRVertex groupByKey2 = new OperatorVertex(new CompilerTestUtil.EmptyTransform("GroupByKey2"));
+  private final IRVertex combine2 = new OperatorVertex(new CompilerTestUtil.EmptyTransform("Combine2"));
   private final IRVertex map22 = new OperatorVertex(new DoTransform(null, null));
 
   private DAG<IRVertex, IREdge> dagNotToOptimize;

--- a/src/test/java/edu/snu/vortex/compiler/optimizer/passes/optimization/LoopFusionPassTest.java
+++ b/src/test/java/edu/snu/vortex/compiler/optimizer/passes/optimization/LoopFusionPassTest.java
@@ -16,7 +16,7 @@
 package edu.snu.vortex.compiler.optimizer.passes.optimization;
 
 import edu.snu.vortex.client.JobLauncher;
-import edu.snu.vortex.compiler.TestUtil;
+import edu.snu.vortex.compiler.CompilerTestUtil;
 import edu.snu.vortex.compiler.ir.IREdge;
 import edu.snu.vortex.compiler.ir.IRVertex;
 import edu.snu.vortex.compiler.ir.LoopVertex;
@@ -53,7 +53,7 @@ public class LoopFusionPassTest {
     final DAGBuilder<IRVertex, IREdge> dagToBeFusedBuilder = new DAGBuilder<>();
     final DAGBuilder<IRVertex, IREdge> dagNotToBeFusedBuilder = new DAGBuilder<>();
 
-    originalALSDAG = TestUtil.compileALSDAG();
+    originalALSDAG = CompilerTestUtil.compileALSDAG();
     groupedDAG = new LoopGroupingPass().process(originalALSDAG);
 
     groupedDAG.topologicalDo(v -> {

--- a/src/test/java/edu/snu/vortex/compiler/optimizer/passes/optimization/LoopInvariantCodeMotionALSInefficientTest.java
+++ b/src/test/java/edu/snu/vortex/compiler/optimizer/passes/optimization/LoopInvariantCodeMotionALSInefficientTest.java
@@ -17,7 +17,7 @@ package edu.snu.vortex.compiler.optimizer.passes.optimization;
 
 import edu.snu.vortex.client.JobLauncher;
 import edu.snu.vortex.common.dag.DAG;
-import edu.snu.vortex.compiler.TestUtil;
+import edu.snu.vortex.compiler.CompilerTestUtil;
 import edu.snu.vortex.compiler.ir.IREdge;
 import edu.snu.vortex.compiler.ir.IRVertex;
 import edu.snu.vortex.compiler.optimizer.passes.LoopGroupingPass;
@@ -40,7 +40,7 @@ public class LoopInvariantCodeMotionALSInefficientTest {
 
   @Before
   public void setUp() throws Exception {
-    inefficientALSDAG = TestUtil.compileALSInefficientDAG();
+    inefficientALSDAG = CompilerTestUtil.compileALSInefficientDAG();
     groupedDAG = new LoopGroupingPass().process(inefficientALSDAG);
   }
 

--- a/src/test/java/edu/snu/vortex/compiler/optimizer/passes/optimization/LoopInvariantCodeMotionPassTest.java
+++ b/src/test/java/edu/snu/vortex/compiler/optimizer/passes/optimization/LoopInvariantCodeMotionPassTest.java
@@ -16,7 +16,7 @@
 package edu.snu.vortex.compiler.optimizer.passes.optimization;
 
 import edu.snu.vortex.client.JobLauncher;
-import edu.snu.vortex.compiler.TestUtil;
+import edu.snu.vortex.compiler.CompilerTestUtil;
 import edu.snu.vortex.compiler.ir.IREdge;
 import edu.snu.vortex.compiler.ir.IRVertex;
 import edu.snu.vortex.compiler.ir.LoopVertex;
@@ -49,7 +49,7 @@ public class LoopInvariantCodeMotionPassTest {
 
   @Before
   public void setUp() throws Exception {
-    originalALSDAG = TestUtil.compileALSDAG();
+    originalALSDAG = CompilerTestUtil.compileALSDAG();
     groupedDAG = new LoopGroupingPass().process(originalALSDAG);
 
     final Optional<LoopVertex> alsLoopOpt = groupedDAG.getTopologicalSort().stream()

--- a/src/test/java/edu/snu/vortex/examples/beam/AlternatingLeastSquareITCase.java
+++ b/src/test/java/edu/snu/vortex/examples/beam/AlternatingLeastSquareITCase.java
@@ -16,7 +16,7 @@
 package edu.snu.vortex.examples.beam;
 
 import edu.snu.vortex.client.JobLauncher;
-import edu.snu.vortex.compiler.TestUtil;
+import edu.snu.vortex.compiler.CompilerTestUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -31,7 +31,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 public final class AlternatingLeastSquareITCase {
   private static final int TIMEOUT = 120000;
   private static final String als = "edu.snu.vortex.examples.beam.AlternatingLeastSquare";
-  private static final String input = TestUtil.rootDir + "/src/main/resources/sample_input_als";
+  private static final String input = CompilerTestUtil.rootDir + "/src/main/resources/sample_input_als";
   private static final String numFeatures = "10";
   private static final String numIteration = "3";
   private static final String dagDirectory = "./dag";

--- a/src/test/java/edu/snu/vortex/examples/beam/BroadcastITCase.java
+++ b/src/test/java/edu/snu/vortex/examples/beam/BroadcastITCase.java
@@ -16,7 +16,7 @@
 package edu.snu.vortex.examples.beam;
 
 import edu.snu.vortex.client.JobLauncher;
-import edu.snu.vortex.compiler.TestUtil;
+import edu.snu.vortex.compiler.CompilerTestUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -31,8 +31,8 @@ import org.powermock.modules.junit4.PowerMockRunner;
 public final class BroadcastITCase {
   private static final int TIMEOUT = 120000;
   private static final String broadcast = "edu.snu.vortex.examples.beam.Broadcast";
-  private static final String input = TestUtil.rootDir + "/src/main/resources/sample_input_mr";
-  private static final String output = TestUtil.rootDir + "/src/main/resources/sample_output";
+  private static final String input = CompilerTestUtil.rootDir + "/src/main/resources/sample_input_mr";
+  private static final String output = CompilerTestUtil.rootDir + "/src/main/resources/sample_output";
   private static final String dagDirectory = "./dag";
 
   private static ArgBuilder builder = new ArgBuilder()

--- a/src/test/java/edu/snu/vortex/examples/beam/MapReduceITCase.java
+++ b/src/test/java/edu/snu/vortex/examples/beam/MapReduceITCase.java
@@ -16,7 +16,7 @@
 package edu.snu.vortex.examples.beam;
 
 import edu.snu.vortex.client.JobLauncher;
-import edu.snu.vortex.compiler.TestUtil;
+import edu.snu.vortex.compiler.CompilerTestUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -31,8 +31,8 @@ import org.powermock.modules.junit4.PowerMockRunner;
 public final class MapReduceITCase {
   private static final int TIMEOUT = 60000;
   private static final String mapReduce = "edu.snu.vortex.examples.beam.MapReduce";
-  private static final String input = TestUtil.rootDir + "/src/main/resources/sample_input_mr";
-  private static final String output = TestUtil.rootDir + "/src/main/resources/sample_output";
+  private static final String input = CompilerTestUtil.rootDir + "/src/main/resources/sample_input_mr";
+  private static final String output = CompilerTestUtil.rootDir + "/src/main/resources/sample_output";
   private static final String dagDirectory = "./dag";
 
   public static ArgBuilder builder = new ArgBuilder()

--- a/src/test/java/edu/snu/vortex/examples/beam/MultinomialLogisticRegressionITCase.java
+++ b/src/test/java/edu/snu/vortex/examples/beam/MultinomialLogisticRegressionITCase.java
@@ -16,7 +16,7 @@
 package edu.snu.vortex.examples.beam;
 
 import edu.snu.vortex.client.JobLauncher;
-import edu.snu.vortex.compiler.TestUtil;
+import edu.snu.vortex.compiler.CompilerTestUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -31,7 +31,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 public final class MultinomialLogisticRegressionITCase {
   private static final int TIMEOUT = 120000;
   private static final String mlr = "edu.snu.vortex.examples.beam.MultinomialLogisticRegression";
-  private static final String input = TestUtil.rootDir + "/src/main/resources/sample_input_mlr";
+  private static final String input = CompilerTestUtil.rootDir + "/src/main/resources/sample_input_mlr";
   private static final String numFeatures = "100";
   private static final String numClasses = "5";
   private static final String numIteration = "3";

--- a/src/test/java/edu/snu/vortex/runtime/RuntimeTestUtil.java
+++ b/src/test/java/edu/snu/vortex/runtime/RuntimeTestUtil.java
@@ -36,7 +36,7 @@ import java.util.stream.IntStream;
 /**
  * Utility class for runtime unit tests.
  */
-public final class TestUtil {
+public final class RuntimeTestUtil {
 
   /**
    * Sends a stage's completion event to scheduler, with all its task groups marked as complete as well.

--- a/src/test/java/edu/snu/vortex/runtime/master/FaultToleranceTest.java
+++ b/src/test/java/edu/snu/vortex/runtime/master/FaultToleranceTest.java
@@ -23,7 +23,7 @@ import edu.snu.vortex.compiler.ir.IRVertex;
 import edu.snu.vortex.compiler.ir.OperatorVertex;
 import edu.snu.vortex.compiler.ir.Transform;
 import edu.snu.vortex.compiler.ir.attribute.Attribute;
-import edu.snu.vortex.runtime.TestUtil;
+import edu.snu.vortex.runtime.RuntimeTestUtil;
 import edu.snu.vortex.runtime.common.comm.ControlMessage;
 import edu.snu.vortex.runtime.common.message.MessageSender;
 import edu.snu.vortex.runtime.common.plan.physical.PhysicalPlan;
@@ -164,7 +164,7 @@ public final class FaultToleranceTest {
 
     // HACK: Set all partition states to committed to see if they are correctly set to lost later.
     dagTopoSorted3Stages.forEach(physicalStage ->
-        TestUtil.sendPartitionStateEventForAStage(partitionManagerMaster, containerManager,
+        RuntimeTestUtil.sendPartitionStateEventForAStage(partitionManagerMaster, containerManager,
             physicalDAG.getOutgoingEdgesOf(physicalStage), physicalStage, PartitionState.State.COMMITTED));
 
     // Wait upto 2 seconds for task groups to be scheduled.
@@ -204,7 +204,7 @@ public final class FaultToleranceTest {
     });
 
     otherTaskGroupIds.forEach(taskGroupId ->
-        TestUtil.sendTaskGroupStateEventToScheduler(scheduler, containerManager,
+        RuntimeTestUtil.sendTaskGroupStateEventToScheduler(scheduler, containerManager,
             taskGroupId, TaskGroupState.State.COMPLETE, MAGIC_SCHEDULE_ATTEMPT_INDEX, null));
 
     taskGroupIdsForFailingExecutor.forEach(failedTaskGroupId -> {
@@ -214,7 +214,7 @@ public final class FaultToleranceTest {
       // wait until the failed task group is rescheduled to an executor, then send a completion event.
       while (state != TaskGroupState.State.EXECUTING) {
       }
-      TestUtil.sendTaskGroupStateEventToScheduler(scheduler, containerManager,
+      RuntimeTestUtil.sendTaskGroupStateEventToScheduler(scheduler, containerManager,
           failedTaskGroupId, TaskGroupState.State.COMPLETE, MAGIC_SCHEDULE_ATTEMPT_INDEX, null);
     });
 
@@ -234,7 +234,7 @@ public final class FaultToleranceTest {
 
     // The 2nd stage will complete without trouble.
     dagTopoSorted3Stages.get(1).getTaskGroupList().forEach(taskGroup ->
-      TestUtil.sendTaskGroupStateEventToScheduler(scheduler, containerManager,
+      RuntimeTestUtil.sendTaskGroupStateEventToScheduler(scheduler, containerManager,
           taskGroup.getTaskGroupId(), TaskGroupState.State.COMPLETE, MAGIC_SCHEDULE_ATTEMPT_INDEX, null));
 
     // Check every 0.5 second for the 2nd stage to complete and 3rd stage's task groups to be scheduled.
@@ -264,7 +264,7 @@ public final class FaultToleranceTest {
 
     final String taskGroupIdToFail = taskGroupIdsForFailingExecutor.iterator().next();
 
-    TestUtil.sendTaskGroupStateEventToScheduler(scheduler, containerManager,
+    RuntimeTestUtil.sendTaskGroupStateEventToScheduler(scheduler, containerManager,
         taskGroupIdToFail, TaskGroupState.State.FAILED_RECOVERABLE, MAGIC_SCHEDULE_ATTEMPT_INDEX,
         TaskGroupState.RecoverableFailureCause.INPUT_READ_FAILURE);
 


### PR DESCRIPTION
* Renames two TestUtils to RuntimeTestUtil and CompilerTestUtil
* Apply different mocking strategy for "Transform" in BatchSchedulerTest to address build failures
* Removes duplicate instantiation for "PartitionManagerMaster" in BatchSchedulerTest