### PR TITLE
[Minor] Improve job state logging

### DIFF
--- a/src/main/java/edu/snu/vortex/runtime/master/JobStateManager.java
+++ b/src/main/java/edu/snu/vortex/runtime/master/JobStateManager.java
@@ -293,6 +293,7 @@ public final class JobStateManager {
 
       if (stageIdToRemainingTaskGroupSet.containsKey(stageId)) {
         final Set<String> remainingTaskGroups = stageIdToRemainingTaskGroupSet.get(stageId);
+        LOG.info("{}: {} TaskGroup(s) to go", stageId, remainingTaskGroups.size());
         remainingTaskGroups.remove(taskGroup.getTaskGroupId());
 
         if (remainingTaskGroups.isEmpty()) {
@@ -441,7 +442,7 @@ public final class JobStateManager {
       final PrintWriter printWriter = new PrintWriter(file);
       printWriter.println(toStringWithPhysicalPlan());
       printWriter.close();
-      LOG.info(String.format("JSON representation of job state for %s(%s) was saved to %s",
+      LOG.debug(String.format("JSON representation of job state for %s(%s) was saved to %s",
           jobId, suffix, file.getPath()));
     } catch (IOException e) {
       LOG.warn(String.format("Cannot store JSON representation of job state for %s(%s) to %s: %s",

--- a/src/main/java/edu/snu/vortex/runtime/master/scheduler/BatchScheduler.java
+++ b/src/main/java/edu/snu/vortex/runtime/master/scheduler/BatchScheduler.java
@@ -174,7 +174,7 @@ public final class BatchScheduler implements Scheduler {
   private void onTaskGroupExecutionComplete(final String executorId,
                                             final TaskGroup taskGroup,
                                             final Boolean isOnHoldToComplete) {
-    LOG.info("{} completed in {}", new Object[]{taskGroup.getTaskGroupId(), executorId});
+    LOG.debug("{} completed in {}", new Object[]{taskGroup.getTaskGroupId(), executorId});
     if (!isOnHoldToComplete) {
       schedulingPolicy.onTaskGroupExecutionComplete(executorId, taskGroup.getTaskGroupId());
     }


### PR DESCRIPTION
This PR improves job state logging by

* removing duplicated logs
* removing messages meaning that job state has been saved to a json file
* adding messages about the number of remaining TaskGroups.