### PR TITLE
[Minor] Support listener removal in MessageEnvironment

### DIFF
--- a/src/main/java/edu/snu/vortex/runtime/common/message/MessageEnvironment.java
+++ b/src/main/java/edu/snu/vortex/runtime/common/message/MessageEnvironment.java
@@ -20,7 +20,7 @@ public interface MessageEnvironment {
   String EXECUTOR_MESSAGE_LISTENER_ID = "EXECUTOR_MESSAGE_LISTENER_ID";
 
   /**
-   * Set up a {@link MessageListener} with a message type id.
+   * Set up a {@link MessageListener} with a listener id.
    *
    * @param listenerId an identifier of the message listener
    * @param listener a message listener
@@ -29,8 +29,15 @@ public interface MessageEnvironment {
   <T> void setupListener(String listenerId, MessageListener<T> listener);
 
   /**
-   * Asynchronously connect to the node called 'receiverId' and return a future of {@link MessageSender} that sends
-   * messages with 'messageTypeId'.
+   * Remove the {@link MessageListener} bound to a specific listener ID.
+   *
+   * @param listenerId the ID of the listener to remove.
+   */
+  void removeListener(String listenerId);
+
+  /**
+   * Asynchronously connect to the node called {@code receiverId} and return a future of {@link MessageSender}
+   * that sends messages to the listener with {@code listenerId}.
    *
    * @param receiverId a receiver id
    * @param listenerId an identifier of the message listener

--- a/src/main/java/edu/snu/vortex/runtime/common/message/local/LocalMessageDispatcher.java
+++ b/src/main/java/edu/snu/vortex/runtime/common/message/local/LocalMessageDispatcher.java
@@ -41,6 +41,11 @@ public final class LocalMessageDispatcher {
     return new LocalMessageSender<>(currentNodeId, currentNodeId, messageTypeId, this);
   }
 
+  void removeListener(final String currentNodeId,
+                      final String listenerId) {
+    nodeIdToMessageListenersMap.get(currentNodeId).remove(listenerId);
+  }
+
   <T> void dispatchSendMessage(
       final String targetId, final String messageTypeId, final T message) {
     final MessageListener listener = nodeIdToMessageListenersMap.get(targetId).get(messageTypeId);

--- a/src/main/java/edu/snu/vortex/runtime/common/message/local/LocalMessageEnvironment.java
+++ b/src/main/java/edu/snu/vortex/runtime/common/message/local/LocalMessageEnvironment.java
@@ -29,6 +29,11 @@ public final class LocalMessageEnvironment implements MessageEnvironment {
   }
 
   @Override
+  public void removeListener(final String listenerId) {
+    dispatcher.removeListener(currentNodeId, listenerId);
+  }
+
+  @Override
   public <T> Future<MessageSender<T>> asyncConnect(
       final String targetId, final String messageTypeId) {
     return CompletableFuture.completedFuture(new LocalMessageSender<T>(


### PR DESCRIPTION
This pr:
- enables `MessageEnvironment` to remove the registered listeners.

This feature should have been implemented in #512, but I missed it.
Also, this feature is a kind of pre-requisite for the #463 because the `RemoteFileMetadata` have to set up it's block subscribing listener and remove it.