### PR TITLE
[Onyx-536] Pick out the thread pool for I/O from PartitionStore

### DIFF
--- a/src/main/java/edu/snu/vortex/client/JobConf.java
+++ b/src/main/java/edu/snu/vortex/client/JobConf.java
@@ -119,19 +119,11 @@ public final class JobConf extends ConfigurationModuleBuilder {
   }
 
   /**
-   * Number of I/O threads for {@link edu.snu.vortex.runtime.executor.data.LocalFileStore}.
+   * Number of I/O threads for partition fetch requests from other executor.
    */
-  @NamedParameter(doc = "Number of I/O threads for LocalFileStore", short_name = "local_file_threads",
+  @NamedParameter(doc = "Number of I/O threads for partition fetch request.", short_name = "io_request_threads",
       default_value = "5")
-  public final class LocalFileStoreNumThreads implements Name<Integer> {
-  }
-
-  /**
-   * Number of I/O threads for {@link edu.snu.vortex.runtime.executor.data.GlusterFileStore}.
-   */
-  @NamedParameter(doc = "Number of I/O threads for GlusterFileStore", short_name = "gluster_file_threads",
-      default_value = "5")
-  public final class GlusterFileStoreNumThreads implements Name<Integer> {
+  public final class IORequestHandleThreadsTotal implements Name<Integer> {
   }
 
   /**

--- a/src/main/java/edu/snu/vortex/client/JobLauncher.java
+++ b/src/main/java/edu/snu/vortex/client/JobLauncher.java
@@ -130,8 +130,7 @@ public final class JobLauncher {
     cl.registerShortNameOfClass(JobConf.DriverMemMb.class);
     cl.registerShortNameOfClass(JobConf.ExecutorJsonPath.class);
     cl.registerShortNameOfClass(JobConf.JVMHeapSlack.class);
-    cl.registerShortNameOfClass(JobConf.LocalFileStoreNumThreads.class);
-    cl.registerShortNameOfClass(JobConf.GlusterFileStoreNumThreads.class);
+    cl.registerShortNameOfClass(JobConf.IORequestHandleThreadsTotal.class);
     cl.registerShortNameOfClass(JobConf.SchedulerTimeoutMs.class);
     cl.registerShortNameOfClass(JobConf.MaxScheduleAttempt.class);
     cl.registerShortNameOfClass(JobConf.PartitionTransferInboundNumThreads.class);

--- a/src/main/java/edu/snu/vortex/runtime/executor/data/GlusterFileStore.java
+++ b/src/main/java/edu/snu/vortex/runtime/executor/data/GlusterFileStore.java
@@ -33,8 +33,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 /**
  * Stores partitions in a mounted GlusterFS volume.
@@ -50,20 +48,17 @@ import java.util.concurrent.Executors;
 public final class GlusterFileStore extends FileStore implements RemoteFileStore {
   public static final String SIMPLE_NAME = "GlusterFileStore";
 
-  private final ExecutorService executorService;
   private final PersistentConnectionToMasterMap persistentConnectionToMasterMap;
   private final String executorId;
 
   @Inject
   private GlusterFileStore(@Parameter(JobConf.GlusterVolumeDirectory.class) final String volumeDirectory,
                            @Parameter(JobConf.JobId.class) final String jobId,
-                           @Parameter(JobConf.GlusterFileStoreNumThreads.class) final int numThreads,
                            @Parameter(JobConf.ExecutorId.class) final String executorId,
                            final InjectionFuture<PartitionManagerWorker> partitionManagerWorker,
                            final PersistentConnectionToMasterMap persistentConnectionToMasterMap) {
     super(volumeDirectory + "/" + jobId, partitionManagerWorker);
     new File(getFileDirectory()).mkdirs();
-    this.executorService = Executors.newFixedThreadPool(numThreads);
     this.executorId = executorId;
     this.persistentConnectionToMasterMap = persistentConnectionToMasterMap;
   }

--- a/src/main/java/edu/snu/vortex/runtime/executor/data/LocalFileStore.java
+++ b/src/main/java/edu/snu/vortex/runtime/executor/data/LocalFileStore.java
@@ -41,16 +41,13 @@ public final class LocalFileStore extends FileStore {
   public static final String SIMPLE_NAME = "LocalFileStore";
 
   private final Map<String, FilePartition> partitionIdToFilePartition;
-  private final ExecutorService executorService;
 
   @Inject
   private LocalFileStore(@Parameter(JobConf.FileDirectory.class) final String fileDirectory,
-                         @Parameter(JobConf.LocalFileStoreNumThreads.class) final int numThreads,
                          final InjectionFuture<PartitionManagerWorker> partitionManagerWorker) {
     super(fileDirectory, partitionManagerWorker);
     this.partitionIdToFilePartition = new ConcurrentHashMap<>();
     new File(fileDirectory).mkdirs();
-    executorService = Executors.newFixedThreadPool(numThreads);
   }
 
   /**


### PR DESCRIPTION
This PR:
- moves the `ExecutorService` from `FileStore`s to `PartitionManagerMaster`.
- makes Netty event handler threads request the partition fetch to this `ExecutorService` instead of being blocked.

Resolves #536.