### PR TITLE
[Onyx-Minor] Fix void coder bug (key of an element can be null)

### DIFF
--- a/src/main/java/edu/snu/onyx/runtime/executor/datatransfer/partitioning/DataSkewHashPartitioner.java
+++ b/src/main/java/edu/snu/onyx/runtime/executor/datatransfer/partitioning/DataSkewHashPartitioner.java
@@ -51,7 +51,7 @@ public final class DataSkewHashPartitioner implements Partitioner {
     IntStream.range(0, hashRange).forEach(hashVal -> elementsByKey.add(new ArrayList<>()));
     elements.forEach(element -> {
       // Hash the data by its key, and "modulo" by the hash range.
-      final int hashVal = Math.abs(element.getKey().hashCode() % hashRange);
+      final int hashVal = Math.abs(PartitionerUtil.getHashCodeFromElementKey(element) % hashRange);
       elementsByKey.get(hashVal).add(element);
     });
 

--- a/src/main/java/edu/snu/onyx/runtime/executor/datatransfer/partitioning/HashPartitioner.java
+++ b/src/main/java/edu/snu/onyx/runtime/executor/datatransfer/partitioning/HashPartitioner.java
@@ -37,7 +37,7 @@ public final class HashPartitioner implements Partitioner {
     IntStream.range(0, dstParallelism).forEach(dstTaskIdx -> elementsByKey.add(new ArrayList<>()));
     elements.forEach(element -> {
       // Hash the data by its key, and "modulo" by the number of destination tasks.
-      final int dstIdx = Math.abs(element.getKey().hashCode() % dstParallelism);
+      final int dstIdx = Math.abs(PartitionerUtil.getHashCodeFromElementKey(element) % dstParallelism);
       elementsByKey.get(dstIdx).add(element);
     });
 

--- a/src/main/java/edu/snu/onyx/runtime/executor/datatransfer/partitioning/PartitionerUtil.java
+++ b/src/main/java/edu/snu/onyx/runtime/executor/datatransfer/partitioning/PartitionerUtil.java
@@ -1,0 +1,16 @@
+package edu.snu.onyx.runtime.executor.datatransfer.partitioning;
+
+import edu.snu.onyx.compiler.ir.Element;
+
+/**
+ * Utility methods for {@link Partitioner}.
+ */
+final class PartitionerUtil {
+  private PartitionerUtil() {
+    // Private constructor.
+  }
+
+  static int getHashCodeFromElementKey(final Element element) {
+    return element.getKey() == null ? 0 : element.getKey().hashCode();
+  }
+}


### PR DESCRIPTION
This PR:
- Handles the `null` value of `Element#getKey()` method.

If this pr is merged, Onyx will be able to handle Shuffle with void key.
(Usually, this situation is generated in Beam by using Combine.globally(...) or View.asSingleton().)