### PR TITLE
[Onyx-584] Prevent Repetitive Scheduling of a TaskGroup during Faults

### DIFF
--- a/src/test/java/edu/snu/onyx/runtime/master/FaultToleranceTest.java
+++ b/src/test/java/edu/snu/onyx/runtime/master/FaultToleranceTest.java
@@ -49,6 +49,7 @@ import org.apache.reef.driver.context.ActiveContext;
 import org.apache.reef.tang.Tang;
 import org.apache.reef.tang.exceptions.InjectionException;
 import org.junit.Before;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;


### PR DESCRIPTION
Resolves #584 .

This PR:

- Prevents repetitive scheduling of a `TaskGroup` whose sibling `TaskGroup` failed recoverably.