### PR TITLE
[Minor] Throw IOException in Coder (Instead of RuntimeException)

### DIFF
--- a/src/main/java/edu/snu/onyx/common/coder/BeamCoder.java
+++ b/src/main/java/edu/snu/onyx/common/coder/BeamCoder.java
@@ -31,21 +31,13 @@ public final class BeamCoder<T> implements Coder<T> {
   }
 
   @Override
-  public void encode(final T value, final OutputStream outStream) {
-    try {
-      beamCoder.encode(value, outStream);
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
+  public void encode(final T value, final OutputStream outStream) throws IOException {
+    beamCoder.encode(value, outStream);
   }
 
   @Override
-  public T decode(final InputStream inStream) {
-    try {
-      return beamCoder.decode(inStream);
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
+  public T decode(final InputStream inStream) throws IOException {
+    return beamCoder.decode(inStream);
   }
 
   @Override

--- a/src/main/java/edu/snu/onyx/common/coder/Coder.java
+++ b/src/main/java/edu/snu/onyx/common/coder/Coder.java
@@ -15,6 +15,7 @@
  */
 package edu.snu.onyx.common.coder;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
@@ -30,8 +31,9 @@ public interface Coder<T> extends Serializable {
    *
    * @param element the element to be encoded
    * @param outStream the stream on which encoded bytes are written
+   * @throws IOException if fail to encode
    */
-  void encode(T element, OutputStream outStream);
+  void encode(T element, OutputStream outStream) throws IOException;
 
   /**
    * Decodes the a value from the given input stream.
@@ -39,8 +41,9 @@ public interface Coder<T> extends Serializable {
    *
    * @param inStream the stream from which bytes are read
    * @return the decoded element
+   * @throws IOException if fail to decode
    */
-  T decode(InputStream inStream);
+  T decode(InputStream inStream) throws IOException;
 
   /**
    * Dummy coder.

--- a/src/main/java/edu/snu/onyx/runtime/executor/data/DataUtil.java
+++ b/src/main/java/edu/snu/onyx/runtime/executor/data/DataUtil.java
@@ -4,6 +4,7 @@ import edu.snu.onyx.common.coder.Coder;
 import edu.snu.onyx.runtime.common.RuntimeIdGenerator;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
@@ -26,10 +27,11 @@ public final class DataUtil {
    * @param block             the block to serialize.
    * @param bytesOutputStream the output stream to write.
    * @return total number of elements in the block.
+   * @throws IOException if fail to serialize.
    */
   public static long serializeBlock(final Coder coder,
                                     final Block block,
-                                    final ByteArrayOutputStream bytesOutputStream) {
+                                    final ByteArrayOutputStream bytesOutputStream) throws IOException {
     long elementsCount = 0;
     for (final Object element : block.getElements()) {
       coder.encode(element, bytesOutputStream);
@@ -46,11 +48,12 @@ public final class DataUtil {
    * @param coder            the coder to decode the bytes.
    * @param inputStream      the input stream which will return the data in the block as bytes.
    * @param deserializedData the list of elements to put the deserialized data.
+   * @throws IOException if fail to deserialize.
    */
   public static void deserializeBlock(final long elementsInBlock,
                                       final Coder coder,
                                       final InputStream inputStream,
-                                      final List deserializedData) {
+                                      final List deserializedData) throws IOException {
     for (int i = 0; i < elementsInBlock; i++) {
       deserializedData.add(coder.decode(inputStream));
     }


### PR DESCRIPTION
This PR:
- throws IOException during encoding / decoding instead of RuntimeException

through this, it would be caught as `PartitionWriteException` or `PartitionFetchException` in `PartitionStore`.