### PR TITLE
[Minor] Disable Concurrent Write in FilePartition

### DIFF
--- a/src/main/java/edu/snu/onyx/runtime/executor/data/PartitionManagerWorker.java
+++ b/src/main/java/edu/snu/onyx/runtime/executor/data/PartitionManagerWorker.java
@@ -196,6 +196,8 @@ public final class PartitionManagerWorker {
   /**
    * Store an iterable of data blocks to a partition in the target {@code PartitionStore}.
    * Invariant: This should not be invoked after a partition is committed.
+   * Invariant: This method may not support concurrent write for a single partition.
+   *            Only one thread have to write at once.
    *
    * @param partitionId    of the partition.
    * @param blocks         to save to a partition.

--- a/src/main/java/edu/snu/onyx/runtime/executor/data/partition/FilePartition.java
+++ b/src/main/java/edu/snu/onyx/runtime/executor/data/partition/FilePartition.java
@@ -23,11 +23,7 @@ import edu.snu.onyx.runtime.executor.data.metadata.BlockMetadata;
 import edu.snu.onyx.runtime.executor.data.metadata.FileMetadata;
 import edu.snu.onyx.runtime.executor.data.FileArea;
 
-import javax.annotation.concurrent.ThreadSafe;
 import java.io.*;
-import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
-import java.nio.channels.FileLock;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.*;
@@ -36,7 +32,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 /**
  * This class represents a partition which is stored in (local or remote) file.
  */
-@ThreadSafe
 public final class FilePartition implements Partition {
 
   private final Coder coder;
@@ -58,6 +53,8 @@ public final class FilePartition implements Partition {
   /**
    * Writes the serialized data of this partition having a specific hash value as a block to the file
    * where this partition resides.
+   * Invariant: This method not support concurrent write for a single partition.
+   *            Only one thread have to write at once.
    *
    * @param serializedData  the serialized data which will become a block.
    * @param elementsInBlock the number of elements in the serialized data.
@@ -70,14 +67,8 @@ public final class FilePartition implements Partition {
     // Reserve a block write and get the metadata.
     final BlockMetadata blockMetadata = metadata.reserveBlock(hashVal, serializedData.length, elementsInBlock);
 
-    try (
-        final FileOutputStream fileOutputStream = new FileOutputStream(filePath, true);
-        final FileChannel fileChannel = fileOutputStream.getChannel();
-        final FileLock fileLock = fileChannel.lock()
-    ) {
-      // Wrap the given serialized data (but not copy it) and write.
-      final ByteBuffer buf = ByteBuffer.wrap(serializedData);
-      fileChannel.write(buf);
+    try (final FileOutputStream fileOutputStream = new FileOutputStream(filePath, true)) {
+      fileOutputStream.write(serializedData);
     }
 
     // Commit if needed.

--- a/src/main/java/edu/snu/onyx/runtime/executor/data/partition/MemoryPartition.java
+++ b/src/main/java/edu/snu/onyx/runtime/executor/data/partition/MemoryPartition.java
@@ -40,7 +40,7 @@ public final class MemoryPartition implements Partition {
 
   /**
    * Writes {@link Block}s to this partition.
-   * Constraint: This should not be invoked after this partition is committed.
+   * Invariant: This should not be invoked after this partition is committed.
    *
    * @param blocksToWrite the {@link Block}s to write.
    * @throws IOException if fail to write.
@@ -58,7 +58,7 @@ public final class MemoryPartition implements Partition {
 
   /**
    * Retrieves the blocks in a specific hash range and deserializes it from this partition.
-   * Constraint: This should not be invoked before this partition is committed.
+   * Invariant: This should not be invoked before this partition is committed.
    *
    * @param hashRange the hash range to retrieve.
    * @return an iterable of deserialized blocks.

--- a/src/main/java/edu/snu/onyx/runtime/executor/data/partition/Partition.java
+++ b/src/main/java/edu/snu/onyx/runtime/executor/data/partition/Partition.java
@@ -29,7 +29,7 @@ public interface Partition {
 
   /**
    * Writes {@link Block}s to this partition.
-   * Constraint: This should not be invoked after this partition is committed.
+   * Invariant: This should not be invoked after this partition is committed.
    *
    * @param blocks the {@link Block}s to write.
    * @return the size of the data per block (only when the data is serialized).
@@ -39,7 +39,7 @@ public interface Partition {
 
   /**
    * Retrieves the blocks in a specific hash range and deserializes it from this partition.
-   * Constraint: This should not be invoked before this partition is committed.
+   * Invariant: This should not be invoked before this partition is committed.
    *
    * @param hashRange the hash range to retrieve.
    * @return an iterable of deserialized blocks.

--- a/src/main/java/edu/snu/onyx/runtime/executor/data/partition/SerializedMemoryPartition.java
+++ b/src/main/java/edu/snu/onyx/runtime/executor/data/partition/SerializedMemoryPartition.java
@@ -46,7 +46,7 @@ public final class SerializedMemoryPartition implements Partition {
 
   /**
    * Writes {@link Block}s to this partition.
-   * Constraint: This should not be invoked after this partition is committed.
+   * Invariant: This should not be invoked after this partition is committed.
    *
    * @param blocksToWrite the {@link Block}s to write.
    * @throws IOException if fail to write.
@@ -76,7 +76,7 @@ public final class SerializedMemoryPartition implements Partition {
 
   /**
    * Retrieves the blocks in a specific hash range and deserializes it from this partition.
-   * Constraint: This should not be invoked before this partition is committed.
+   * Invariant: This should not be invoked before this partition is committed.
    *
    * @param hashRange the hash range to retrieve.
    * @return an iterable of deserialized blocks.

--- a/src/main/java/edu/snu/onyx/runtime/executor/data/stores/PartitionStore.java
+++ b/src/main/java/edu/snu/onyx/runtime/executor/data/stores/PartitionStore.java
@@ -60,7 +60,9 @@ public interface PartitionStore {
    * If the partition exists already, appends the data to it.
    * This method supports concurrent write.
    * If the data is needed to be "incrementally" written (and read),
-   * each block can be committed right after being written by using {@param commitPerBlock}.
+   * each block can be committed right after being written by using {@code commitPerBlock}.
+   * Invariant: This method may not support concurrent write for a single partition.
+   *            Only one thread have to write at once.
    *
    * @param partitionId    of the partition.
    * @param blocks         to save to a partition.


### PR DESCRIPTION
This PR:
- disables concurrent write in `FilePartition` and does not use `fileChannel#position` method.

This is because the `fileChannel#position` method is unstable (not supported in some circumstances) and concurrent write is not used at now.
(The block reservation will be removed during further data plane refactoring process.)