### PR TITLE
[Minor] Avoid NullPointerException in getting ExecutionProperty.Value

### DIFF
--- a/common/src/main/java/edu/snu/onyx/common/dag/DAGBuilder.java
+++ b/common/src/main/java/edu/snu/onyx/common/dag/DAGBuilder.java
@@ -267,8 +267,8 @@ public final class DAGBuilder<V extends Vertex, E extends Edge<V>> implements Se
         }));
     // All vertices connected with OneToOne edge should have identical Parallelism execution property.
     vertices.forEach(v -> incomingEdges.get(v).stream().filter(e -> e instanceof IREdge).map(e -> (IREdge) e)
-        .filter(e -> e.getProperty(ExecutionProperty.Key.DataCommunicationPattern)
-        .equals(DataCommunicationPatternProperty.Value.OneToOne))
+        .filter(e -> DataCommunicationPatternProperty.Value.OneToOne
+                .equals(e.getProperty(ExecutionProperty.Key.DataCommunicationPattern)))
         .filter(e -> !Boolean.TRUE.equals(e.isSideInput())).forEach(e -> {
           if (e.getSrc() != null && e.getDst() != null
               && !(e.getSrc() instanceof LoopVertex) && !(e.getDst() instanceof LoopVertex)

--- a/compiler/optimizer/src/main/java/edu/snu/onyx/compiler/optimizer/pass/compiletime/annotating/DisaggregationEdgeDataStorePass.java
+++ b/compiler/optimizer/src/main/java/edu/snu/onyx/compiler/optimizer/pass/compiletime/annotating/DisaggregationEdgeDataStorePass.java
@@ -40,8 +40,8 @@ public final class DisaggregationEdgeDataStorePass extends AnnotatingPass {
     dag.getVertices().forEach(vertex -> { // Initialize the DataStore of the DAG with GlusterFileStore.
       final List<IREdge> inEdges = dag.getIncomingEdgesOf(vertex);
       inEdges.forEach(edge -> {
-        if (edge.getProperty(ExecutionProperty.Key.DataStore)
-            .equals(DataStoreProperty.Value.LocalFileStore)) {
+        if (DataStoreProperty.Value.LocalFileStore
+              .equals(edge.getProperty(ExecutionProperty.Key.DataStore))) {
           edge.setProperty(DataStoreProperty.of(DataStoreProperty.Value.GlusterFileStore));
         }
       });

--- a/compiler/optimizer/src/main/java/edu/snu/onyx/compiler/optimizer/pass/compiletime/annotating/PadoEdgeDataStorePass.java
+++ b/compiler/optimizer/src/main/java/edu/snu/onyx/compiler/optimizer/pass/compiletime/annotating/PadoEdgeDataStorePass.java
@@ -50,8 +50,8 @@ public final class PadoEdgeDataStorePass extends AnnotatingPass {
           } else if (fromReservedToTransient(edge)) {
             edge.setProperty(DataStoreProperty.of(DataStoreProperty.Value.LocalFileStore));
           } else {
-            if (edge.getProperty(ExecutionProperty.Key.DataCommunicationPattern)
-                .equals(DataCommunicationPatternProperty.Value.OneToOne)) {
+            if (DataCommunicationPatternProperty.Value.OneToOne
+                  .equals(edge.getProperty(ExecutionProperty.Key.DataCommunicationPattern))) {
               edge.setProperty(DataStoreProperty.of(DataStoreProperty.Value.MemoryStore));
             } else {
               edge.setProperty(DataStoreProperty.of(DataStoreProperty.Value.LocalFileStore));
@@ -69,10 +69,10 @@ public final class PadoEdgeDataStorePass extends AnnotatingPass {
    * @return whether or not the edge satisfies the condition.
    */
   static boolean fromTransientToReserved(final IREdge irEdge) {
-    return irEdge.getSrc().getProperty(ExecutionProperty.Key.ExecutorPlacement)
-        .equals(ExecutorPlacementProperty.TRANSIENT)
-        && irEdge.getDst().getProperty(ExecutionProperty.Key.ExecutorPlacement)
-        .equals(ExecutorPlacementProperty.RESERVED);
+    return ExecutorPlacementProperty.TRANSIENT
+        .equals(irEdge.getSrc().getProperty(ExecutionProperty.Key.ExecutorPlacement))
+        && ExecutorPlacementProperty.RESERVED
+        .equals(irEdge.getDst().getProperty(ExecutionProperty.Key.ExecutorPlacement));
   }
 
   /**
@@ -81,9 +81,9 @@ public final class PadoEdgeDataStorePass extends AnnotatingPass {
    * @return whether or not the edge satisfies the condition.
    */
   static boolean fromReservedToTransient(final IREdge irEdge) {
-    return irEdge.getSrc().getProperty(ExecutionProperty.Key.ExecutorPlacement)
-        .equals(ExecutorPlacementProperty.RESERVED)
-        && irEdge.getDst().getProperty(ExecutionProperty.Key.ExecutorPlacement)
-        .equals(ExecutorPlacementProperty.TRANSIENT);
+    return ExecutorPlacementProperty.RESERVED
+        .equals(irEdge.getSrc().getProperty(ExecutionProperty.Key.ExecutorPlacement))
+        && ExecutorPlacementProperty.TRANSIENT
+        .equals(irEdge.getDst().getProperty(ExecutionProperty.Key.ExecutorPlacement));
   }
 }

--- a/compiler/optimizer/src/main/java/edu/snu/onyx/compiler/optimizer/pass/compiletime/annotating/SailfishEdgeDataStorePass.java
+++ b/compiler/optimizer/src/main/java/edu/snu/onyx/compiler/optimizer/pass/compiletime/annotating/SailfishEdgeDataStorePass.java
@@ -38,11 +38,11 @@ public final class SailfishEdgeDataStorePass extends AnnotatingPass {
     dag.getVertices().forEach(vertex -> {
       // Find the merger vertex inserted by reshaping pass.
       if (dag.getIncomingEdgesOf(vertex).stream().anyMatch(irEdge ->
-          irEdge.getProperty(ExecutionProperty.Key.DataCommunicationPattern)
-            .equals(DataCommunicationPatternProperty.Value.ScatterGather))) {
+              DataCommunicationPatternProperty.Value.ScatterGather
+          .equals(irEdge.getProperty(ExecutionProperty.Key.DataCommunicationPattern)))) {
         dag.getIncomingEdgesOf(vertex).forEach(edgeToMerger -> {
-          if (edgeToMerger.getProperty(ExecutionProperty.Key.DataCommunicationPattern)
-              .equals(DataCommunicationPatternProperty.Value.ScatterGather)) {
+          if (DataCommunicationPatternProperty.Value.ScatterGather
+          .equals(edgeToMerger.getProperty(ExecutionProperty.Key.DataCommunicationPattern))) {
             // Pass data through memory to the merger vertex.
             edgeToMerger.setProperty(DataStoreProperty.of(DataStoreProperty.Value.MemoryStore));
           }

--- a/compiler/optimizer/src/main/java/edu/snu/onyx/compiler/optimizer/pass/compiletime/reshaping/DataSkewReshapingPass.java
+++ b/compiler/optimizer/src/main/java/edu/snu/onyx/compiler/optimizer/pass/compiletime/reshaping/DataSkewReshapingPass.java
@@ -46,16 +46,16 @@ public final class DataSkewReshapingPass extends ReshapingPass {
     dag.topologicalDo(v -> {
       // We care about OperatorVertices that have any incoming edges that are of type ScatterGather.
       if (v instanceof OperatorVertex && dag.getIncomingEdgesOf(v).stream().anyMatch(irEdge ->
-          irEdge.getProperty(ExecutionProperty.Key.DataCommunicationPattern)
-                              .equals(DataCommunicationPatternProperty.Value.ScatterGather))) {
+          DataCommunicationPatternProperty.Value.ScatterGather
+          .equals(irEdge.getProperty(ExecutionProperty.Key.DataCommunicationPattern)))) {
         final MetricCollectionBarrierVertex metricCollectionBarrierVertex = new MetricCollectionBarrierVertex();
         metricCollectionVertices.add(metricCollectionBarrierVertex);
         builder.addVertex(v);
         builder.addVertex(metricCollectionBarrierVertex);
         dag.getIncomingEdgesOf(v).forEach(edge -> {
           // we insert the metric collection vertex when we meet a scatter gather edge
-          if (edge.getProperty(ExecutionProperty.Key.DataCommunicationPattern)
-              .equals(DataCommunicationPatternProperty.Value.ScatterGather)) {
+          if (DataCommunicationPatternProperty.Value.ScatterGather
+                .equals(edge.getProperty(ExecutionProperty.Key.DataCommunicationPattern))) {
             // We then insert the dynamicOptimizationVertex between the vertex and incoming vertices.
             final IREdge newEdge = new IREdge(DataCommunicationPatternProperty.Value.OneToOne,
                 edge.getSrc(), metricCollectionBarrierVertex, edge.getCoder());

--- a/compiler/optimizer/src/main/java/edu/snu/onyx/compiler/optimizer/pass/compiletime/reshaping/SailfishReshapingPass.java
+++ b/compiler/optimizer/src/main/java/edu/snu/onyx/compiler/optimizer/pass/compiletime/reshaping/SailfishReshapingPass.java
@@ -41,11 +41,11 @@ public final class SailfishReshapingPass extends ReshapingPass {
       // We care about OperatorVertices that have any incoming edge that
       // has ScatterGather as data communication pattern.
       if (v instanceof OperatorVertex && dag.getIncomingEdgesOf(v).stream().anyMatch(irEdge ->
-          irEdge.getProperty(ExecutionProperty.Key.DataCommunicationPattern)
-                              .equals(DataCommunicationPatternProperty.Value.ScatterGather))) {
+              DataCommunicationPatternProperty.Value.ScatterGather
+          .equals(irEdge.getProperty(ExecutionProperty.Key.DataCommunicationPattern)))) {
         dag.getIncomingEdgesOf(v).forEach(edge -> {
-          if (edge.getProperty(ExecutionProperty.Key.DataCommunicationPattern)
-              .equals(DataCommunicationPatternProperty.Value.ScatterGather)) {
+          if (DataCommunicationPatternProperty.Value.ScatterGather
+                .equals(edge.getProperty(ExecutionProperty.Key.DataCommunicationPattern))) {
             // Insert a merger vertex having transform that write received data immediately
             // before the vertex receiving shuffled data.
             final OperatorVertex iFileMergerVertex = new OperatorVertex(new RelayTransform());

--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/PartitionManagerWorker.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/PartitionManagerWorker.java
@@ -142,7 +142,7 @@ public final class PartitionManagerWorker {
     if (optionalResultData.isPresent()) {
       // Partition resides in this evaluator!
       return CompletableFuture.completedFuture(optionalResultData.get());
-    } else if (partitionStore.equals(DataStoreProperty.Value.GlusterFileStore)) {
+    } else if (DataStoreProperty.Value.GlusterFileStore.equals(partitionStore)) {
       throw new PartitionFetchException(new Throwable("Cannot find a partition in remote store."));
     } else {
       // We don't have the partition here...
@@ -245,7 +245,7 @@ public final class PartitionManagerWorker {
             .setPartitionId(partitionId)
             .setState(ControlMessage.PartitionStateFromExecutor.COMMITTED);
 
-    if (partitionStore.equals(DataStoreProperty.Value.GlusterFileStore)) {
+    if (DataStoreProperty.Value.GlusterFileStore.equals(partitionStore)) {
       partitionStateChangedMsgBuilder.setLocation(REMOTE_FILE_STORE);
     } else {
       partitionStateChangedMsgBuilder.setLocation(executorId);
@@ -345,8 +345,8 @@ public final class PartitionManagerWorker {
       @Override
       public void run() {
         try {
-          if (partitionStore.equals(DataStoreProperty.Value.LocalFileStore)
-              || partitionStore.equals(DataStoreProperty.Value.GlusterFileStore)) {
+          if (DataStoreProperty.Value.LocalFileStore.equals(partitionStore)
+              || DataStoreProperty.Value.GlusterFileStore.equals(partitionStore)) {
             // TODO #492: Modularize the data communication pattern. Remove execution property value dependant code.
             final FileStore fileStore = (FileStore) getPartitionStore(partitionStore);
             outputStream.writeFileAreas(fileStore.getFileAreas(outputStream.getPartitionId(),

--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/datatransfer/OutputWriter.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/datatransfer/OutputWriter.java
@@ -102,11 +102,11 @@ public final class OutputWriter extends DataTransfer implements AutoCloseable {
     DataCommunicationPatternProperty.Value comValue =
         runtimeEdge.getProperty(ExecutionProperty.Key.DataCommunicationPattern);
 
-    if (comValue.equals(DataCommunicationPatternProperty.Value.OneToOne)) {
+    if (DataCommunicationPatternProperty.Value.OneToOne.equals(comValue)) {
       writeOneToOne(blocksToWrite);
-    } else if (comValue.equals(DataCommunicationPatternProperty.Value.BroadCast)) {
+    } else if (DataCommunicationPatternProperty.Value.BroadCast.equals(comValue)) {
       writeBroadcast(blocksToWrite);
-    } else if (comValue.equals(DataCommunicationPatternProperty.Value.ScatterGather)) {
+    } else if (DataCommunicationPatternProperty.Value.ScatterGather.equals(comValue)) {
       // If the dynamic optimization which detects data skew is enabled, sort the data and write it.
       if (isDataSizeMetricCollectionEdge) {
         dataSkewWrite(blocksToWrite);

--- a/tests/src/test/java/edu/snu/onyx/tests/compiler/optimizer/pass/compiletime/annotating/DefaultPartitionerPassTest.java
+++ b/tests/src/test/java/edu/snu/onyx/tests/compiler/optimizer/pass/compiletime/annotating/DefaultPartitionerPassTest.java
@@ -57,14 +57,14 @@ public class DefaultPartitionerPassTest {
     final DAG<IRVertex, IREdge> processedDAG = partitionerPass.apply(compiledDAG);
 
     processedDAG.getVertices().forEach(v -> processedDAG.getIncomingEdgesOf(v).stream()
-        .filter(e -> e.getProperty(ExecutionProperty.Key.DataCommunicationPattern)
-                      .equals(DataCommunicationPatternProperty.Value.ScatterGather))
+        .filter(e -> DataCommunicationPatternProperty.Value.ScatterGather
+                      .equals(e.getProperty(ExecutionProperty.Key.DataCommunicationPattern)))
         .forEach(e -> assertEquals(e.getProperty(ExecutionProperty.Key.Partitioner),
             PartitionerProperty.Value.HashPartitioner)));
 
     processedDAG.getVertices().forEach(v -> processedDAG.getIncomingEdgesOf(v).stream()
-        .filter(e -> !e.getProperty(ExecutionProperty.Key.DataCommunicationPattern)
-                        .equals(DataCommunicationPatternProperty.Value.ScatterGather))
+        .filter(e -> !DataCommunicationPatternProperty.Value.ScatterGather
+                      .equals(e.getProperty(ExecutionProperty.Key.DataCommunicationPattern)))
         .forEach(e -> assertEquals(e.getProperty(ExecutionProperty.Key.Partitioner),
             PartitionerProperty.Value.IntactPartitioner)));
   }

--- a/tests/src/test/java/edu/snu/onyx/tests/compiler/optimizer/pass/compiletime/composite/DataSkewCompositePassTest.java
+++ b/tests/src/test/java/edu/snu/onyx/tests/compiler/optimizer/pass/compiletime/composite/DataSkewCompositePassTest.java
@@ -79,8 +79,8 @@ public class DataSkewCompositePassTest {
     final Integer originalVerticesNum = mrDAG.getVertices().size();
     final Long numOfScatterGatherEdges = mrDAG.getVertices().stream().filter(irVertex ->
         mrDAG.getIncomingEdgesOf(irVertex).stream().anyMatch(irEdge ->
-            irEdge.getProperty(ExecutionProperty.Key.DataCommunicationPattern)
-              .equals(DataCommunicationPatternProperty.Value.ScatterGather)))
+            DataCommunicationPatternProperty.Value.ScatterGather
+            .equals(irEdge.getProperty(ExecutionProperty.Key.DataCommunicationPattern))))
         .count();
     final DAG<IRVertex, IREdge> processedDAG = new DataSkewCompositePass().apply(mrDAG);
 

--- a/tests/src/test/java/edu/snu/onyx/tests/compiler/optimizer/pass/compiletime/composite/DisaggregationPassTest.java
+++ b/tests/src/test/java/edu/snu/onyx/tests/compiler/optimizer/pass/compiletime/composite/DisaggregationPassTest.java
@@ -53,8 +53,8 @@ public class DisaggregationPassTest {
 
     processedDAG.getTopologicalSort().forEach(irVertex -> {
       processedDAG.getIncomingEdgesOf(irVertex).forEach(edgeToMerger -> {
-        if (edgeToMerger.getProperty(ExecutionProperty.Key.DataCommunicationPattern)
-            .equals(DataCommunicationPatternProperty.Value.OneToOne)) {
+        if (DataCommunicationPatternProperty.Value.OneToOne
+              .equals(edgeToMerger.getProperty(ExecutionProperty.Key.DataCommunicationPattern))) {
           assertEquals(DataStoreProperty.Value.MemoryStore, edgeToMerger.getProperty(ExecutionProperty.Key.DataStore));
         } else {
           assertEquals(DataStoreProperty.Value.GlusterFileStore,

--- a/tests/src/test/java/edu/snu/onyx/tests/compiler/optimizer/pass/compiletime/composite/SailfishPassTest.java
+++ b/tests/src/test/java/edu/snu/onyx/tests/compiler/optimizer/pass/compiletime/composite/SailfishPassTest.java
@@ -52,12 +52,12 @@ public class SailfishPassTest {
 
     processedDAG.getTopologicalSort().forEach(irVertex -> {
       if (processedDAG.getIncomingEdgesOf(irVertex).stream().anyMatch(irEdge ->
-          irEdge.getProperty(ExecutionProperty.Key.DataCommunicationPattern)
-            .equals(DataCommunicationPatternProperty.Value.ScatterGather))) {
+              DataCommunicationPatternProperty.Value.ScatterGather
+          .equals(irEdge.getProperty(ExecutionProperty.Key.DataCommunicationPattern)))) {
         // Merger vertex
         processedDAG.getIncomingEdgesOf(irVertex).forEach(edgeToMerger -> {
-          if (edgeToMerger.getProperty(ExecutionProperty.Key.DataCommunicationPattern)
-              .equals(DataCommunicationPatternProperty.Value.ScatterGather)) {
+          if (DataCommunicationPatternProperty.Value.ScatterGather
+          .equals(edgeToMerger.getProperty(ExecutionProperty.Key.DataCommunicationPattern))) {
             assertEquals(DataFlowModelProperty.Value.Push,
                 edgeToMerger.getProperty(ExecutionProperty.Key.DataFlowModel));
             assertEquals(DataStoreProperty.Value.MemoryStore,

--- a/tests/src/test/java/edu/snu/onyx/tests/runtime/executor/datatransfer/DataTransferTest.java
+++ b/tests/src/test/java/edu/snu/onyx/tests/runtime/executor/datatransfer/DataTransferTest.java
@@ -275,7 +275,7 @@ public final class DataTransferTest {
     edgeProperties.put(DataStoreProperty.of(store));
     final RuntimeEdge dummyEdge;
 
-    if (commPattern.equals(DataCommunicationPatternProperty.Value.ScatterGather)) {
+    if (DataCommunicationPatternProperty.Value.ScatterGather.equals(commPattern)) {
       final IRVertex srcMockVertex = mock(IRVertex.class);
       final IRVertex dstMockVertex = mock(IRVertex.class);
       final PhysicalStage srcStage = setupStages("srcStage", taskGroupPrefix);
@@ -310,7 +310,7 @@ public final class DataTransferTest {
       final InputReader reader =
           new InputReader(dstTaskIndex, taskGroupPrefix + dstTaskIndex, srcVertex, dummyEdge, receiver);
 
-      if (commPattern.equals(DataCommunicationPatternProperty.Value.OneToOne)) {
+      if (DataCommunicationPatternProperty.Value.OneToOne.equals(commPattern)) {
         assertEquals(1, reader.getSourceParallelism());
       } else {
         assertEquals(PARALLELISM_TEN, reader.getSourceParallelism());
@@ -328,7 +328,7 @@ public final class DataTransferTest {
     // Compare (should be the same)
     final List flattenedWrittenData = flatten(dataWrittenList);
     final List flattenedReadData = flatten(dataReadList);
-    if (commPattern.equals(DataCommunicationPatternProperty.Value.BroadCast)) {
+    if (DataCommunicationPatternProperty.Value.BroadCast.equals(commPattern)) {
       final List broadcastedWrittenData = new ArrayList<>();
       IntStream.range(0, PARALLELISM_TEN).forEach(i -> broadcastedWrittenData.addAll(flattenedWrittenData));
       assertEquals(broadcastedWrittenData.size(), flattenedReadData.size());


### PR DESCRIPTION
This PR:
* Avoid `NullPointerException` when comparing `ExecutionProperty.Value` with non-null value by using `(non-null value).equals(ExecutionProperty.Value)` instead of `ExecutionProperty.Value.equals(non-null value)`.