### PR TITLE
[Minor] Fix a bug that prevented the visualizer from handling Tasks

### DIFF
--- a/bin/json2dot.py
+++ b/bin/json2dot.py
@@ -180,7 +180,7 @@ class NormalVertex:
             label += '\\n{}'.format(clazz_name)
         except:
             pass
-        if (self.properties['class'] == 'MetricCollectionBarrierVertex'):
+        if ('class' in self.properties and self.properties['class'] == 'MetricCollectionBarrierVertex'):
             shape = ', shape=box'
             label += '\\nMetricCollectionBarrier'
         else:


### PR DESCRIPTION
This commit fixes a bug introduced by #556.
Class 'NormalVertex' covers not only IRVertices but also (Physical)Tasks.
#556 made the visualizer access a property that doesn't exist in Tasks.