### PR TITLE
[Onyx-298] Remove Used Blocks from Memory

### DIFF
--- a/common/src/main/java/edu/snu/onyx/common/ir/edge/executionproperty/UsedDataHandlingProperty.java
+++ b/common/src/main/java/edu/snu/onyx/common/ir/edge/executionproperty/UsedDataHandlingProperty.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2017 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.onyx.common.ir.edge.executionproperty;
+
+import edu.snu.onyx.common.ir.executionproperty.ExecutionProperty;
+
+/**
+ * UsedDataHandling ExecutionProperty.
+ * This property represents the strategy of handling used data.
+ */
+public final class UsedDataHandlingProperty extends ExecutionProperty<UsedDataHandlingProperty.Value> {
+  private UsedDataHandlingProperty(final Value value) {
+    super(Key.UsedDataHandling, value);
+  }
+
+  public static UsedDataHandlingProperty of(final Value value) {
+    return new UsedDataHandlingProperty(value);
+  }
+
+  /**
+   * Possible values of UsedDataHandling ExecutionProperty.
+   */
+  public enum Value {
+    Discard,
+    Keep
+  }
+}

--- a/common/src/main/java/edu/snu/onyx/common/ir/executionproperty/ExecutionProperty.java
+++ b/common/src/main/java/edu/snu/onyx/common/ir/executionproperty/ExecutionProperty.java
@@ -65,7 +65,7 @@ public abstract class ExecutionProperty<T> implements Serializable {
     MetricCollection,
     Partitioner,
     KeyExtractor,
-    WriteOptimization, // TODO #492: to be removed.
+    UsedDataHandling,
 
     // Applies to IRVertex
     DynamicOptimizationType,

--- a/compiler/optimizer/src/main/java/edu/snu/onyx/compiler/optimizer/pass/compiletime/annotating/DefaultUsedDataHandlingPass.java
+++ b/compiler/optimizer/src/main/java/edu/snu/onyx/compiler/optimizer/pass/compiletime/annotating/DefaultUsedDataHandlingPass.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2017 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.onyx.compiler.optimizer.pass.compiletime.annotating;
+
+import edu.snu.onyx.common.dag.DAG;
+import edu.snu.onyx.common.ir.edge.IREdge;
+import edu.snu.onyx.common.ir.edge.executionproperty.DataStoreProperty;
+import edu.snu.onyx.common.ir.edge.executionproperty.UsedDataHandlingProperty;
+import edu.snu.onyx.common.ir.executionproperty.ExecutionProperty;
+import edu.snu.onyx.common.ir.vertex.IRVertex;
+
+import java.util.Collections;
+
+/**
+ * Pass for initiating IREdge UsedDataHandling ExecutionProperty with default values.
+ */
+public final class DefaultUsedDataHandlingPass extends AnnotatingPass {
+
+  public DefaultUsedDataHandlingPass() {
+    super(ExecutionProperty.Key.UsedDataHandling, Collections.singleton(ExecutionProperty.Key.DataStore));
+  }
+
+  @Override
+  public DAG<IRVertex, IREdge> apply(final DAG<IRVertex, IREdge> dag) {
+    dag.topologicalDo(irVertex ->
+        dag.getIncomingEdgesOf(irVertex).forEach(irEdge -> {
+          if (irEdge.getProperty(ExecutionProperty.Key.UsedDataHandling) == null) {
+            final DataStoreProperty.Value dataStoreValue = irEdge.getProperty(ExecutionProperty.Key.DataStore);
+            if (DataStoreProperty.Value.MemoryStore.equals(dataStoreValue)
+                || DataStoreProperty.Value.SerializedMemoryStore.equals(dataStoreValue)) {
+              irEdge.setProperty(UsedDataHandlingProperty.of(UsedDataHandlingProperty.Value.Discard));
+            } else {
+              irEdge.setProperty(UsedDataHandlingProperty.of(UsedDataHandlingProperty.Value.Keep));
+            }
+          }
+        }));
+    return dag;
+  }
+}

--- a/compiler/optimizer/src/main/java/edu/snu/onyx/compiler/optimizer/pass/compiletime/composite/InitiationCompositePass.java
+++ b/compiler/optimizer/src/main/java/edu/snu/onyx/compiler/optimizer/pass/compiletime/composite/InitiationCompositePass.java
@@ -31,7 +31,8 @@ public final class InitiationCompositePass extends CompositePass {
         new DefaultVertexExecutorPlacementPass(),
         new DefaultPartitionerPass(),
         new DefaultEdgeDataFlowModelPass(),
-        new DefaultEdgeDataStorePass()
+        new DefaultEdgeDataStorePass(),
+        new DefaultUsedDataHandlingPass()
     ));
   }
 }

--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/PartitionManagerWorker.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/PartitionManagerWorker.java
@@ -15,7 +15,9 @@
  */
 package edu.snu.onyx.runtime.executor.data;
 
+import edu.snu.onyx.common.exception.UnsupportedExecutionPropertyException;
 import edu.snu.onyx.common.ir.edge.executionproperty.DataStoreProperty;
+import edu.snu.onyx.common.ir.edge.executionproperty.UsedDataHandlingProperty;
 import edu.snu.onyx.conf.JobConf;
 import edu.snu.onyx.common.coder.Coder;
 import edu.snu.onyx.runtime.common.data.HashRange;
@@ -38,6 +40,8 @@ import javax.inject.Inject;
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,6 +62,7 @@ public final class PartitionManagerWorker {
   private final ConcurrentMap<String, Coder> runtimeEdgeIdToCoder;
   private final PartitionTransfer partitionTransfer;
   private final ExecutorService ioThreadExecutorService;
+  private final Map<String, AtomicInteger> partitionToRemainingRead;
 
   @Inject
   private PartitionManagerWorker(@Parameter(JobConf.ExecutorId.class) final String executorId,
@@ -77,6 +82,7 @@ public final class PartitionManagerWorker {
     this.runtimeEdgeIdToCoder = new ConcurrentHashMap<>();
     this.partitionTransfer = partitionTransfer;
     this.ioThreadExecutorService = Executors.newFixedThreadPool(numThreads);
+    this.partitionToRemainingRead = new ConcurrentHashMap<>();
   }
 
   /**
@@ -140,6 +146,8 @@ public final class PartitionManagerWorker {
     final Optional<Iterable<NonSerializedBlock>> optionalResultBlocks = store.getBlocks(partitionId, hashRange);
 
     if (optionalResultBlocks.isPresent()) {
+      handleUsedData(partitionStore, partitionId);
+
       // Partition resides in this evaluator!
       try {
         return CompletableFuture.completedFuture(DataUtil.concatNonSerBlocks(optionalResultBlocks.get()));
@@ -232,16 +240,31 @@ public final class PartitionManagerWorker {
    * Subscribers waiting for the data of the target partition are notified when the partition is committed.
    * Also, further subscription about a committed partition will not blocked but get the data in it and finished.
    *
-   * @param partitionId    of the partition.
-   * @param partitionStore to store the partition.
-   * @param blockSizeInfo  the size metric of blocks.
-   * @param srcIRVertexId  of the source task.
+   * @param partitionId       the ID of the partition.
+   * @param partitionStore    the store to save the partition.
+   * @param blockSizeInfo     the size metric of blocks.
+   * @param srcIRVertexId     the IR vertex ID of the source task.
+   * @param expectedReadTotal the expected number of read for this partition.
+   * @param usedDataHandling  how to handle the used partition.
    */
   public void commitPartition(final String partitionId,
                               final DataStoreProperty.Value partitionStore,
                               final List<Long> blockSizeInfo,
-                              final String srcIRVertexId) {
+                              final String srcIRVertexId,
+                              final int expectedReadTotal,
+                              final UsedDataHandlingProperty.Value usedDataHandling) {
     LOG.info("CommitPartition: {}", partitionId);
+    switch (usedDataHandling) {
+      case Discard:
+        partitionToRemainingRead.put(partitionId, new AtomicInteger(expectedReadTotal));
+        break;
+      case Keep:
+        // Do nothing but just keep the data.
+        break;
+      default:
+        throw new UnsupportedExecutionPropertyException("This used data handling property is not supported.");
+    }
+
     final PartitionStore store = getPartitionStore(partitionStore);
     store.commitPartition(partitionId);
     final ControlMessage.PartitionStateChangedMsg.Builder partitionStateChangedMsgBuilder =
@@ -283,8 +306,8 @@ public final class PartitionManagerWorker {
   /**
    * Remove the partition from store.
    *
-   * @param partitionId    of the partition to remove.
-   * @param partitionStore tha the partition is stored.
+   * @param partitionId    the ID of the partition to remove.
+   * @param partitionStore the store which contains the partition.
    */
   public void removePartition(final String partitionId,
                               final DataStoreProperty.Value partitionStore) {
@@ -315,6 +338,29 @@ public final class PartitionManagerWorker {
               .build());
     } else {
       throw new PartitionFetchException(new Throwable("Cannot find corresponding partition " + partitionId));
+    }
+  }
+
+  /**
+   * Handles used {@link edu.snu.onyx.runtime.executor.data.partition.Partition}.
+   *
+   * @param partitionStore the store which contains the partition.
+   * @param partitionId    the ID of the {@link edu.snu.onyx.runtime.executor.data.partition.Partition}.
+   */
+  private void handleUsedData(final DataStoreProperty.Value partitionStore,
+                              final String partitionId) {
+    final AtomicInteger remainingExpectedRead = partitionToRemainingRead.get(partitionId);
+    if (remainingExpectedRead != null) {
+      if (remainingExpectedRead.decrementAndGet() == 0) {
+        // This partition should be spilt.
+        partitionToRemainingRead.remove(partitionId);
+        ioThreadExecutorService.submit(new Runnable() {
+          @Override
+          public void run() {
+            removePartition(partitionId, partitionStore);
+          }
+        });
+      }
     }
   }
 

--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/datatransfer/OutputWriter.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/datatransfer/OutputWriter.java
@@ -17,10 +17,7 @@ package edu.snu.onyx.runtime.executor.datatransfer;
 
 import edu.snu.onyx.common.KeyExtractor;
 import edu.snu.onyx.common.exception.*;
-import edu.snu.onyx.common.ir.edge.executionproperty.DataCommunicationPatternProperty;
-import edu.snu.onyx.common.ir.edge.executionproperty.DataStoreProperty;
-import edu.snu.onyx.common.ir.edge.executionproperty.MetricCollectionProperty;
-import edu.snu.onyx.common.ir.edge.executionproperty.PartitionerProperty;
+import edu.snu.onyx.common.ir.edge.executionproperty.*;
 import edu.snu.onyx.common.ir.vertex.IRVertex;
 import edu.snu.onyx.common.ir.executionproperty.ExecutionProperty;
 import edu.snu.onyx.runtime.common.RuntimeIdGenerator;
@@ -28,6 +25,7 @@ import edu.snu.onyx.runtime.common.plan.RuntimeEdge;
 import edu.snu.onyx.runtime.executor.data.Block;
 import edu.snu.onyx.runtime.executor.data.partitioner.*;
 import edu.snu.onyx.runtime.executor.data.PartitionManagerWorker;
+import edu.snu.onyx.runtime.executor.datatransfer.communication.OneToOne;
 
 import javax.annotation.Nullable;
 import java.util.*;
@@ -126,7 +124,10 @@ public final class OutputWriter extends DataTransfer implements AutoCloseable {
   @Override
   public void close() {
     // Commit partition.
-    partitionManagerWorker.commitPartition(partitionId, channelDataPlacement, accumulatedBlockSizeInfo, srcVertexId);
+    final UsedDataHandlingProperty.Value usedDataHandling =
+        runtimeEdge.getProperty(ExecutionProperty.Key.UsedDataHandling);
+    partitionManagerWorker.commitPartition(partitionId, channelDataPlacement,
+        accumulatedBlockSizeInfo, srcVertexId, getDstParallelism(), usedDataHandling);
   }
 
   private void writeOneToOne(final List<Block> blocksToWrite) {
@@ -181,6 +182,8 @@ public final class OutputWriter extends DataTransfer implements AutoCloseable {
    * @return the parallelism of the destination task.
    */
   private int getDstParallelism() {
-    return dstVertex == null ? 1 : dstVertex.getProperty(ExecutionProperty.Key.Parallelism);
+    return dstVertex == null
+        || OneToOne.class.equals(runtimeEdge.getProperty(ExecutionProperty.Key.DataCommunicationPattern))
+        ? 1 : dstVertex.getProperty(ExecutionProperty.Key.Parallelism);
   }
 }

--- a/tests/src/test/java/edu/snu/onyx/tests/compiler/optimizer/TestPolicy.java
+++ b/tests/src/test/java/edu/snu/onyx/tests/compiler/optimizer/TestPolicy.java
@@ -44,6 +44,7 @@ public final class TestPolicy implements Policy {
     policy.add(new DefaultPartitionerPass());
     policy.add(new DefaultEdgeDataFlowModelPass());
     policy.add(new DefaultEdgeDataStorePass());
+    policy.add(new DefaultUsedDataHandlingPass());
     policy.add(new DefaultStagePartitioningPass());
     policy.add(new ScheduleGroupPass());
 

--- a/tests/src/test/java/edu/snu/onyx/tests/compiler/optimizer/policy/PolicyBuilderTest.java
+++ b/tests/src/test/java/edu/snu/onyx/tests/compiler/optimizer/policy/PolicyBuilderTest.java
@@ -14,21 +14,21 @@ public final class PolicyBuilderTest {
   @Test
   public void testDisaggregationPolicy() {
     final Policy disaggregationPolicy = new DisaggregationPolicy();
-    assertEquals(32, disaggregationPolicy.getCompileTimePasses().size());
+    assertEquals(37, disaggregationPolicy.getCompileTimePasses().size());
     assertEquals(0, disaggregationPolicy.getRuntimePasses().size());
   }
 
   @Test
   public void testPadoPolicy() {
     final Policy padoPolicy = new PadoPolicy();
-    assertEquals(34, padoPolicy.getCompileTimePasses().size());
+    assertEquals(39, padoPolicy.getCompileTimePasses().size());
     assertEquals(0, padoPolicy.getRuntimePasses().size());
   }
 
   @Test
   public void testDataSkewPolicy() {
     final Policy dataSkewPolicy = new DataSkewPolicy();
-    assertEquals(41, dataSkewPolicy.getCompileTimePasses().size());
+    assertEquals(47, dataSkewPolicy.getCompileTimePasses().size());
     assertEquals(1, dataSkewPolicy.getRuntimePasses().size());
   }
 

--- a/tests/src/test/java/edu/snu/onyx/tests/runtime/executor/datatransfer/DataTransferTest.java
+++ b/tests/src/test/java/edu/snu/onyx/tests/runtime/executor/datatransfer/DataTransferTest.java
@@ -17,10 +17,7 @@ package edu.snu.onyx.tests.runtime.executor.datatransfer;
 
 import edu.snu.onyx.common.eventhandler.PubSubEventHandlerWrapper;
 import edu.snu.onyx.common.ir.edge.IREdge;
-import edu.snu.onyx.common.ir.edge.executionproperty.DataCommunicationPatternProperty;
-import edu.snu.onyx.common.ir.edge.executionproperty.DataStoreProperty;
-import edu.snu.onyx.common.ir.edge.executionproperty.KeyExtractorProperty;
-import edu.snu.onyx.common.ir.edge.executionproperty.PartitionerProperty;
+import edu.snu.onyx.common.ir.edge.executionproperty.*;
 import edu.snu.onyx.common.ir.vertex.BoundedSourceVertex;
 import edu.snu.onyx.common.ir.vertex.IRVertex;
 import edu.snu.onyx.common.ir.vertex.executionproperty.ParallelismProperty;
@@ -104,8 +101,8 @@ public final class DataTransferTest {
   private static final DataStoreProperty.Value SER_MEMORY_STORE = DataStoreProperty.Value.SerializedMemoryStore;
   private static final DataStoreProperty.Value LOCAL_FILE_STORE = DataStoreProperty.Value.LocalFileStore;
   private static final DataStoreProperty.Value REMOTE_FILE_STORE = DataStoreProperty.Value.GlusterFileStore;
-  private static final String tmp_LOCAL_FILE_DIRECTORY = "./tmpLocalFiles";
-  private static final String tmp_REMOTE_FILE_DIRECTORY = "./tmpRemoteFiles";
+  private static final String TMP_LOCAL_FILE_DIRECTORY = "./tmpLocalFiles";
+  private static final String TMP_REMOTE_FILE_DIRECTORY = "./tmpRemoteFiles";
   private static final int PARALLELISM_TEN = 10;
   private static final String EDGE_PREFIX_TEMPLATE = "Dummy(%d)";
   private static final AtomicInteger TEST_INDEX = new AtomicInteger(0);
@@ -157,8 +154,8 @@ public final class DataTransferTest {
 
   @After
   public void tearDown() throws IOException {
-    FileUtils.deleteDirectory(new File(tmp_LOCAL_FILE_DIRECTORY));
-    FileUtils.deleteDirectory(new File(tmp_REMOTE_FILE_DIRECTORY));
+    FileUtils.deleteDirectory(new File(TMP_LOCAL_FILE_DIRECTORY));
+    FileUtils.deleteDirectory(new File(TMP_REMOTE_FILE_DIRECTORY));
   }
 
   private PartitionManagerWorker createWorker(final String executorId, final LocalMessageDispatcher messageDispatcher,
@@ -172,8 +169,8 @@ public final class DataTransferTest {
     final Injector injector = nameClientInjector.forkInjector(executorConfiguration);
     injector.bindVolatileInstance(MessageEnvironment.class, messageEnvironment);
     injector.bindVolatileInstance(PersistentConnectionToMasterMap.class, conToMaster);
-    injector.bindVolatileParameter(JobConf.FileDirectory.class, tmp_LOCAL_FILE_DIRECTORY);
-    injector.bindVolatileParameter(JobConf.GlusterVolumeDirectory.class, tmp_REMOTE_FILE_DIRECTORY);
+    injector.bindVolatileParameter(JobConf.FileDirectory.class, TMP_LOCAL_FILE_DIRECTORY);
+    injector.bindVolatileParameter(JobConf.GlusterVolumeDirectory.class, TMP_REMOTE_FILE_DIRECTORY);
     final PartitionManagerWorker partitionManagerWorker;
     final MetricManagerWorker metricManagerWorker;
     try {
@@ -273,6 +270,7 @@ public final class DataTransferTest {
     edgeProperties.put(PartitionerProperty.of(PartitionerProperty.Value.HashPartitioner));
 
     edgeProperties.put(DataStoreProperty.of(store));
+    edgeProperties.put(UsedDataHandlingProperty.of(UsedDataHandlingProperty.Value.Keep));
     final RuntimeEdge dummyEdge;
 
     if (DataCommunicationPatternProperty.Value.ScatterGather.equals(commPattern)) {


### PR DESCRIPTION
This PR:
- Adds `UsedDataHandling` execution property which represents the used data handling strategy.
- Adds a default annotation pass for the property which assigns `Discard` value for memory stores and `Keep` to disk stores.
- Removes `garbageCollectLocalIntermediateData()` and integrates with the `UsedDataHandling` property.

Resolves #298.