### PR TITLE
[Minor] Improve transform names for visualization

### DIFF
--- a/bin/json2dot.py
+++ b/bin/json2dot.py
@@ -175,9 +175,13 @@ class NormalVertex:
         except:
             pass
         try:
-            clazz = self.properties['transform'].split('.')[-1]
-            clazz_name = clazz.split('$')[0]
-            label += '\\n{}'.format(clazz_name)
+            transform = self.properties['transform'].split(':')
+            transform_name = transform[0]
+            try:
+                class_name = transform[1].split('{')[0].split('.')[-1].split('$')[0].split('@')[0]
+            except IndexError:
+                class_name = '?'
+            label += '\\n{}:{}'.format(transform_name, class_name)
         except:
             pass
         if ('class' in self.properties and self.properties['class'] == 'MetricCollectionBarrierVertex'):


### PR DESCRIPTION
This commit improves transform names for visualization

Some examples are:
 - MapElements => DoTransform:MapElements
 - Combine => DoTransform:Combine
 - GlobalWindows => WindowTransform:GlobalWindows
 - `<init>:403#20ff67585e33a8f6>}` => BroadcastTransform:SimplePCollectionView