### PR TITLE
[Minor] Fix Used Data Handling

### DIFF
--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/BlockManagerWorker.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/BlockManagerWorker.java
@@ -399,11 +399,13 @@ public final class BlockManagerWorker {
             final FileStore fileStore = (FileStore) getBlockStore(blockStore);
             outputStream.writeFileAreas(fileStore.getFileAreas(outputStream.getBlockId(),
                 outputStream.getKeyRange())).close();
+            handleUsedData(blockStore, outputStream.getBlockId());
           } else if (DataStoreProperty.Value.SerializedMemoryStore.equals(blockStore)) {
             final SerializedMemoryStore serMemoryStore = (SerializedMemoryStore) getBlockStore(blockStore);
             final Optional<Iterable<SerializedPartition>> optionalResult = serMemoryStore.getSerializedPartitions(
                 outputStream.getBlockId(), outputStream.getKeyRange());
             outputStream.writeSerializedPartitions(optionalResult.get()).close();
+            handleUsedData(blockStore, outputStream.getBlockId());
           } else {
             final Iterable block =
                 retrieveDataFromBlock(outputStream.getBlockId(), outputStream.getRuntimeEdgeId(),


### PR DESCRIPTION
This PR:
- calls `handledUsedData` method during `onPullRequest` also.

This was the cause of the OOM during Sailfish experiment.