### PR TITLE
[Minor] Replace Grpc Message Environment with NCS

### DIFF
--- a/client/src/main/java/edu/snu/onyx/client/JobLauncher.java
+++ b/client/src/main/java/edu/snu/onyx/client/JobLauncher.java
@@ -20,7 +20,6 @@ import edu.snu.onyx.conf.JobConf;
 import edu.snu.onyx.driver.OnyxDriver;
 import edu.snu.onyx.runtime.common.message.MessageEnvironment;
 import edu.snu.onyx.runtime.common.message.MessageParameters;
-import edu.snu.onyx.runtime.common.message.grpc.GrpcMessageEnvironment;
 import org.apache.beam.sdk.repackaged.org.apache.commons.lang3.SerializationUtils;
 import org.apache.reef.client.DriverConfiguration;
 import org.apache.reef.client.DriverLauncher;
@@ -164,7 +163,6 @@ public final class JobLauncher {
    */
   private static Configuration getDriverMessageConf() throws InjectionException {
     return TANG.newConfigurationBuilder()
-        .bindImplementation(MessageEnvironment.class, GrpcMessageEnvironment.class)
         .bindNamedParameter(MessageParameters.SenderId.class, MessageEnvironment.MASTER_COMMUNICATION_ID)
         .build();
   }

--- a/runtime/common/src/main/java/edu/snu/onyx/runtime/common/message/MessageEnvironment.java
+++ b/runtime/common/src/main/java/edu/snu/onyx/runtime/common/message/MessageEnvironment.java
@@ -1,6 +1,6 @@
 package edu.snu.onyx.runtime.common.message;
 
-import edu.snu.onyx.runtime.common.message.grpc.GrpcMessageEnvironment;
+import edu.snu.onyx.runtime.common.message.ncs.NcsMessageEnvironment;
 import org.apache.reef.tang.annotations.DefaultImplementation;
 
 import java.util.concurrent.Future;
@@ -9,7 +9,7 @@ import java.util.concurrent.Future;
  * Set up {@link MessageListener}s to handle incoming messages on this node, and connect to remote nodes and return
  * {@link MessageSender}s to send message to them.
  */
-@DefaultImplementation(GrpcMessageEnvironment.class)
+@DefaultImplementation(NcsMessageEnvironment.class)
 public interface MessageEnvironment {
 
   // The ID of the master used for distinguish the sender or receiver.

--- a/runtime/driver/src/main/java/edu/snu/onyx/driver/OnyxDriver.java
+++ b/runtime/driver/src/main/java/edu/snu/onyx/driver/OnyxDriver.java
@@ -18,9 +18,7 @@ package edu.snu.onyx.driver;
 import edu.snu.onyx.common.ir.IdManager;
 import edu.snu.onyx.conf.JobConf;
 import edu.snu.onyx.runtime.common.RuntimeIdGenerator;
-import edu.snu.onyx.runtime.common.message.MessageEnvironment;
 import edu.snu.onyx.runtime.common.message.MessageParameters;
-import edu.snu.onyx.runtime.common.message.grpc.GrpcMessageEnvironment;
 import edu.snu.onyx.runtime.master.RuntimeMaster;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.driver.client.JobMessageObserver;
@@ -212,7 +210,6 @@ public final class OnyxDriver {
 
   private Configuration getExecutorMessageConfiguration(final String executorId) {
     return Tang.Factory.getTang().newConfigurationBuilder()
-        .bindImplementation(MessageEnvironment.class, GrpcMessageEnvironment.class)
         .bindNamedParameter(MessageParameters.SenderId.class, executorId)
         .build();
   }


### PR DESCRIPTION
As a hot-fix for #691, this PR:
- replaces `GrpcMessagEnvironment` with `NcsMessageEnvironment`
- removes tang configurations bounded to a specific message environment (to enable to change message environment by just changing `DefaultImplementation` of `MessageEnvironment`)