### PR TITLE
[Onyx-692] Support Java9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@ limitations under the License.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.20</version>
+                <version>2.20.1</version>
                 <executions>
                     <execution>
                         <goals>
@@ -145,7 +145,7 @@ limitations under the License.
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.9.1</version>
+                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <id>add-source</id>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -29,8 +29,8 @@ limitations under the License.
     <name>Onyx Unit Tests and Integration Tests</name>
 
     <properties>
-        <mockito.version>1.10.19</mockito.version>
-        <powermock.version>1.6.6</powermock.version>
+        <mockito.version>2.13.0</mockito.version>
+        <powermock.version>2.0.0-beta.5</powermock.version>
         <junit.version>4.12</junit.version>
     </properties>
 
@@ -58,7 +58,7 @@ limitations under the License.
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>
         </dependency>
         <dependency>
@@ -69,7 +69,7 @@ limitations under the License.
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
+            <artifactId>powermock-api-mockito2</artifactId>
             <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>

--- a/tests/src/test/java/edu/snu/onyx/tests/client/ClientEndpointTest.java
+++ b/tests/src/test/java/edu/snu/onyx/tests/client/ClientEndpointTest.java
@@ -61,7 +61,7 @@ public class ClientEndpointTest {
   public void testState() throws Exception {
     // Create a simple client endpoint that returns given job state.
     final StateTranslator stateTranslator = mock(StateTranslator.class);
-    when(stateTranslator.translateState(any())).then(state -> state.getArgumentAt(0, JobState.State.class));
+    when(stateTranslator.translateState(any())).then(state -> state.getArgument(0));
     final ClientEndpoint clientEndpoint = new TestClientEndpoint(stateTranslator);
     assertEquals(clientEndpoint.getJobState(), JobState.State.READY);
 


### PR DESCRIPTION
This PR:

- upgrades old dependency and plugin versions to support Java 9
  - Mockito 1 to 2 with appropriate changes

I've tested on my mac with Java 9.0.1. It works well with the following changes.

resolves #692. 