### PR TITLE
[Onyx-695] Make WriteFiles to be executed properly

### DIFF
--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/blocktransfer/BlockInputStream.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/blocktransfer/BlockInputStream.java
@@ -137,9 +137,13 @@ public final class BlockInputStream<T> implements Iterable<T>, BlockStream {
     executorService.submit(() -> {
       try {
         final long startTime = System.currentTimeMillis();
+        // In case of VoidCoder of Beam, its decode() function always returns null and input stream is
+        // already ended. But elementQueue should be non-empty to process latter task, so decode() should be
+        // invoked in spite of the end of stream.
         if (byteBufInputStream.isEnded()) {
           try {
             elementQueue.add(coder.decode(byteBufInputStream));
+            // In this case, exception raised in coder can be ignored
           } catch (final CoderException e) {
             LOG.warn("CoderException was thrown when invoke decode() on end of stream, but can be ignored");
           }

--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/blocktransfer/BlockInputStream.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/blocktransfer/BlockInputStream.java
@@ -19,6 +19,7 @@ import edu.snu.onyx.common.coder.Coder;
 import edu.snu.onyx.common.ir.edge.executionproperty.DataStoreProperty;
 import edu.snu.onyx.runtime.common.data.KeyRange;
 import io.netty.buffer.ByteBuf;
+import org.apache.beam.sdk.coders.CoderException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -136,6 +137,13 @@ public final class BlockInputStream<T> implements Iterable<T>, BlockStream {
     executorService.submit(() -> {
       try {
         final long startTime = System.currentTimeMillis();
+        if (byteBufInputStream.isEnded()) {
+          try {
+            elementQueue.add(coder.decode(byteBufInputStream));
+          } catch (final CoderException e) {
+            LOG.warn("CoderException was thrown when invoke decode() on end of stream, but can be ignored");
+          }
+        }
         while (!byteBufInputStream.isEnded()) {
           elementQueue.add(coder.decode(byteBufInputStream));
         }

--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/blocktransfer/ClosableBlockingIterable.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/blocktransfer/ClosableBlockingIterable.java
@@ -126,13 +126,12 @@ public final class ClosableBlockingIterable<T> implements Iterable<T>, AutoClose
           while (iterable.list.size() <= index && !iterable.closed) {
             iterable.wait();
           }
+          if (iterable.list.size() <= index) {
+            throw new NoSuchElementException();
+          }
           final T element = iterable.list.get(index);
           index++;
-          if (element == null) {
-            throw new NoSuchElementException();
-          } else {
-            return element;
-          }
+          return element;
         }
       } catch (final InterruptedException e) {
         throw new RuntimeException(e);

--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/blocktransfer/FrameDecoder.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/blocktransfer/FrameDecoder.java
@@ -278,7 +278,6 @@ final class FrameDecoder extends ByteToMessageDecoder {
    * @throws InterruptedException when interrupted while marking the end of stream
    */
   private void onDataFrameEnd(final ChannelHandlerContext ctx) {
-    inputStream.startDecodingThreadIfNeeded();
     if (isLastFrame) {
       LOG.debug("Transport {}:{}, where the block sender is {} and the receiver is {}, is now closed",
           new Object[]{isPullTransfer ? "pull" : "push", transferId, ctx.channel().remoteAddress(),
@@ -286,6 +285,7 @@ final class FrameDecoder extends ByteToMessageDecoder {
       inputStream.markAsEnded();
       (isPullTransfer ? pullTransferIdToInputStream : pushTransferIdToInputStream).remove(transferId);
     }
+    inputStream.startDecodingThreadIfNeeded();
     inputStream = null;
   }
 }


### PR DESCRIPTION
Closes #695 

* Fixed `startDecodeThreadIfNeeded` to invoke `coder.decode()` at least once.
* Resolve race condition between starting decoding thread and closing `ByteBufInputStream`.
* Fixed `ClosableBlockingIterable` to allow `null` element.