### PR TITLE
[Onyx-702] Fix BeamCoder to catch CoderException and throw IOException instead

### DIFF
--- a/compiler/frontend/src/main/java/edu/snu/onyx/compiler/frontend/beam/coder/BeamCoder.java
+++ b/compiler/frontend/src/main/java/edu/snu/onyx/compiler/frontend/beam/coder/BeamCoder.java
@@ -41,7 +41,7 @@ public final class BeamCoder<T> implements Coder<T> {
   public void encode(final T value, final OutputStream outStream) throws IOException {
     try {
       beamCoder.encode(value, outStream);
-    } catch (CoderException e) {
+    } catch (final CoderException e) {
       throw new IOException(e);
     }
   }
@@ -50,7 +50,7 @@ public final class BeamCoder<T> implements Coder<T> {
   public T decode(final InputStream inStream) throws IOException {
     try {
       return beamCoder.decode(inStream);
-    } catch (CoderException e) {
+    } catch (final CoderException e) {
       throw new IOException(e);
     }
   }

--- a/compiler/frontend/src/main/java/edu/snu/onyx/compiler/frontend/beam/coder/BeamCoder.java
+++ b/compiler/frontend/src/main/java/edu/snu/onyx/compiler/frontend/beam/coder/BeamCoder.java
@@ -16,6 +16,7 @@
 package edu.snu.onyx.compiler.frontend.beam.coder;
 
 import edu.snu.onyx.common.coder.Coder;
+import org.apache.beam.sdk.coders.CoderException;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -38,12 +39,20 @@ public final class BeamCoder<T> implements Coder<T> {
 
   @Override
   public void encode(final T value, final OutputStream outStream) throws IOException {
-    beamCoder.encode(value, outStream);
+    try {
+      beamCoder.encode(value, outStream);
+    } catch (CoderException e) {
+      throw new IOException(e);
+    }
   }
 
   @Override
   public T decode(final InputStream inStream) throws IOException {
-    return beamCoder.decode(inStream);
+    try {
+      return beamCoder.decode(inStream);
+    } catch (CoderException e) {
+      throw new IOException(e);
+    }
   }
 
   @Override

--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/blocktransfer/BlockInputStream.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/blocktransfer/BlockInputStream.java
@@ -144,7 +144,7 @@ public final class BlockInputStream<T> implements Iterable<T>, BlockStream {
             elementQueue.add(coder.decode(byteBufInputStream));
             // In this case, exception raised in coder can be ignored
           } catch (final IOException e) {
-            LOG.warn("CoderException was thrown when invoke decode() on end of stream, but can be ignored");
+            LOG.warn("IOException was thrown when invoke decode() on end of stream, but can be ignored");
           }
         }
         while (!byteBufInputStream.isEnded()) {


### PR DESCRIPTION
Closes #702 

* Fix `BeamCoder`'s `encode()` and `decode()` methods to catch `CoderException`