### PR TITLE
[Minor] Make Control Messages to Be GCed

### DIFF
--- a/runtime/master/src/main/java/edu/snu/onyx/runtime/master/BlockManagerMaster.java
+++ b/runtime/master/src/main/java/edu/snu/onyx/runtime/master/BlockManagerMaster.java
@@ -294,18 +294,18 @@ public final class BlockManagerMaster {
   void onRequestBlockLocation(final ControlMessage.Message message,
                               final MessageContext messageContext) {
     assert (message.getType() == ControlMessage.MessageType.RequestBlockLocation);
-    final ControlMessage.RequestBlockLocationMsg requestPartitionLocationMsg =
-        message.getRequestBlockLocationMsg();
+    final String blockId = message.getRequestBlockLocationMsg().getBlockId();
+    final long requestId = message.getId();
     final Lock readLock = lock.readLock();
     readLock.lock();
     try {
       final CompletableFuture<String> locationFuture
-          = getBlockLocationFuture(requestPartitionLocationMsg.getBlockId());
+          = getBlockLocationFuture(blockId);
       locationFuture.whenComplete((location, throwable) -> {
         final ControlMessage.BlockLocationInfoMsg.Builder infoMsgBuilder =
             ControlMessage.BlockLocationInfoMsg.newBuilder()
-                .setRequestId(message.getId())
-                .setBlockId(requestPartitionLocationMsg.getBlockId());
+                .setRequestId(requestId)
+                .setBlockId(blockId);
         if (throwable == null) {
           infoMsgBuilder.setOwnerExecutorId(location);
         } else {
@@ -404,6 +404,7 @@ public final class BlockManagerMaster {
                                          final MessageContext messageContext) {
     assert (message.getType() == ControlMessage.MessageType.RequestPartitionMetadata);
     final ControlMessage.RequestPartitionMetadataMsg requestMsg = message.getRequestPartitionMetadataMsg();
+    final long requestId = message.getId();
     final String blockId = requestMsg.getBlockId();
 
     final Lock readLock = lock.readLock();
@@ -415,7 +416,7 @@ public final class BlockManagerMaster {
       locationFuture.whenComplete((location, throwable) -> {
         final ControlMessage.MetadataResponseMsg.Builder responseBuilder =
             ControlMessage.MetadataResponseMsg.newBuilder()
-                .setRequestId(message.getId());
+                .setRequestId(requestId);
         if (throwable == null) {
           // Well committed.
           final BlockMetadata metadata = blockIdToMetadata.get(blockId);


### PR DESCRIPTION
This PR:
- makes control messages (including internal messages like `RequestBlockLocationMsg`) to be garbage-collected 

Master node heap profiling result through Jmap during experiment
Before this PR:
```
   2  num     #instances         #bytes  class name
   3 ----------------------------------------------
   4    1:       5148838     7139866272  [B
   5    2:      41352697     3233140752  [C
   6    3:      12009935     2305907520  edu.snu.onyx.runtime.common.comm.ControlMessage$Message
   7    4:      46769937     2228587216  [Ljava.lang.Object;
   8    5:      27754490     1554251440  java.io.ObjectStreamClass$WeakClassKey
   9    6:      37928106     1213699392  java.lang.String
  10    7:      12009877      768632128  edu.snu.onyx.runtime.common.comm.ControlMessage$RequestBlockLocationMsg
  11    8:      12009876      768632064  java.util.concurrent.CompletableFuture$UniWhenComplete
  12    9:          6288      643157880  [I
  13   10:      13715793      548631720  java.io.SerialCallbackContext
  14   11:      12009876      480395040  edu.snu.onyx.runtime.common.message.ncs.NcsMessageContext
  15   12:      12009876      480395040  edu.snu.onyx.runtime.master.BlockManagerMaster$$Lambda$202/1105318865
  16   13:      12061589      385970848  java.util.concurrent.CompletableFuture
  17   14:        949743      148444760  [Ljava.util.HashMap$Node;
  18   15:       2738209      131434032  java.util.HashMap$Node
  19   16:       1119573       80609256  io.netty.buffer.UnpooledHeapByteBuf
  20   17:       1069031       68417984  java.util.HashMap
  21   18:       1494526       59781040  edu.snu.onyx.common.StateMachine$Transition
  22   19:       1679291       53737312  com.google.protobuf.LiteralByteString
  23   20:       1119527       44781080  com.google.protobuf.UnknownFieldSet$Builder
  24   21:        559741       40301352  com.google.protobuf.CodedInputStream
  25   22:        832595       33303800  edu.snu.onyx.common.StateMachine$State
```

After this PR:
  ```
   2  num     #instances         #bytes  class name
   3 ----------------------------------------------
   4    1:       4677914     6374242952  [B
   5    2:      42179517     2016819384  [Ljava.lang.Object;
   6    3:      21959618     1541769512  [C
   7    4:      25021600     1401209600  java.io.ObjectStreamClass$WeakClassKey
   8    5:      18846934      603101888  java.lang.String
   9    6:       8284743      530223552  java.util.concurrent.CompletableFuture$UniWhenComplete
  10    7:         78669      525758536  [I
  11    8:      12365240      494609600  java.io.SerialCallbackContext
  12    9:       8284743      331389720  edu.snu.onyx.runtime.common.message.ncs.NcsMessageContext
  13   10:       8284743      331389720  edu.snu.onyx.runtime.master.BlockManagerMaster$$Lambda$202/897571989
  14   11:       8336456      266766592  java.util.concurrent.CompletableFuture
  15   12:        949370      148377696  [Ljava.util.HashMap$Node;
  16   13:       2736356      131345088  java.util.HashMap$Node
  17   14:        508437       97619904  edu.snu.onyx.runtime.common.comm.ControlMessage$Message
  18   15:       1017069       73228968  io.netty.buffer.UnpooledHeapByteBuf
  19   16:       1068645       68393280  java.util.HashMap
  20   17:       1494526       59781040  edu.snu.onyx.common.StateMachine$Transition
  21   18:       1525503       48816096  com.google.protobuf.LiteralByteString
  22   19:       1016967       40678680  com.google.protobuf.UnknownFieldSet$Builder
  23   20:        508470       36609840  com.google.protobuf.CodedInputStream
  24   21:        832595       33303800  edu.snu.onyx.common.StateMachine$State
  25   22:        508387       32536768  edu.snu.onyx.runtime.common.comm.ControlMessage$RequestBlockLocationMsg
```