### PR TITLE
[Onyx-709] Wait for Executor Launch before Scheduling TaskGroups

### DIFF
--- a/runtime/driver/src/main/java/edu/snu/onyx/driver/OnyxDriver.java
+++ b/runtime/driver/src/main/java/edu/snu/onyx/driver/OnyxDriver.java
@@ -45,7 +45,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.logging.LogManager;

--- a/runtime/master/src/main/java/edu/snu/onyx/runtime/master/RuntimeMaster.java
+++ b/runtime/master/src/main/java/edu/snu/onyx/runtime/master/RuntimeMaster.java
@@ -190,7 +190,7 @@ public final class RuntimeMaster {
     try {
       containerRequestEventResult.get();
     } catch (final Exception e) {
-      e.printStackTrace();
+      LOG.error("Exception while requesting for a container: ", e);
       throw new ContainerException(e);
     }
   }


### PR DESCRIPTION
Resolves #709 .

This PR:

- Waits for all requested executors to be launched before scheduling `TaskGroups` of a submitted job.