### PR TITLE
[Onyx-715] Remote Block Metadata in File

### DIFF
--- a/runtime/common/src/main/java/edu/snu/onyx/runtime/common/message/ncs/NcsMessageEnvironment.java
+++ b/runtime/common/src/main/java/edu/snu/onyx/runtime/common/message/ncs/NcsMessageEnvironment.java
@@ -186,18 +186,12 @@ public final class NcsMessageEnvironment implements MessageEnvironment {
       case ScheduleTaskGroup:
       case BlockStateChanged:
       case ExecutorFailed:
-      case CommitPartition:
-      case RemovePartitionMetadata:
       case DataSizeMetric:
       case ContainerFailed:
         return MessageType.Send;
       case RequestBlockLocation:
-      case RequestPartitionMetadata:
-      case ReservePartition:
         return MessageType.Request;
       case BlockLocationInfo:
-      case MetadataResponse:
-      case ReservePartitionResponse:
         return MessageType.Reply;
       default:
         throw new IllegalArgumentException(controlMessage.toString());
@@ -208,10 +202,6 @@ public final class NcsMessageEnvironment implements MessageEnvironment {
     switch (controlMessage.getType()) {
       case RequestBlockLocation:
         return controlMessage.getRequestBlockLocationMsg().getExecutorId();
-      case RequestPartitionMetadata:
-        return controlMessage.getRequestPartitionMetadataMsg().getExecutorId();
-      case ReservePartition:
-        return controlMessage.getReservePartitionMsg().getExecutorId();
       default:
         throw new IllegalArgumentException(controlMessage.toString());
     }
@@ -221,10 +211,6 @@ public final class NcsMessageEnvironment implements MessageEnvironment {
     switch (controlMessage.getType()) {
       case BlockLocationInfo:
         return controlMessage.getBlockLocationInfoMsg().getRequestId();
-      case MetadataResponse:
-        return controlMessage.getMetadataResponseMsg().getRequestId();
-      case ReservePartitionResponse:
-        return controlMessage.getReservePartitionResponseMsg().getRequestId();
       default:
         throw new IllegalArgumentException(controlMessage.toString());
     }

--- a/runtime/common/src/main/proto/ControlMessage.proto
+++ b/runtime/common/src/main/proto/ControlMessage.proto
@@ -15,13 +15,6 @@ enum MessageType {
     ExecutorFailed = 6;
     ContainerFailed = 7;
     MetricMessageReceived = 8;
-    // Messages for metadata passing
-    CommitPartition = 9;
-    RemovePartitionMetadata = 10;
-    RequestPartitionMetadata = 11;
-    MetadataResponse = 12;
-    ReservePartition = 13;
-    ReservePartitionResponse = 14;
 }
 
 message Message {
@@ -37,13 +30,6 @@ message Message {
     optional ExecutorFailedMsg executorFailedMsg = 10;
     optional ContainerFailedMsg containerFailedMsg = 11;
     optional MetricMsg metricMsg = 12;
-    // Messages for metadata passing
-    optional MetadataResponseMsg metadataResponseMsg = 13;
-    optional CommitPartitionMsg commitPartitionMsg = 14;
-    optional RemovePartitionMetadataMsg removePartitionMetadataMsg = 15;
-    optional RequestPartitionMetadataMsg requestPartitionMetadataMsg = 16;
-    optional ReservePartitionMsg reservePartitionMsg = 17;
-    optional ReservePartitionResponseMsg reservePartitionResponseMsg = 18;
 }
 
 // Messages from Master to Executors
@@ -148,49 +134,7 @@ enum BlockStore {
     REMOTE_FILE = 3;
 }
 
-// Messages for metadata passing
-// Messages from Master to Executors
-message MetadataResponseMsg {
-    required int64 requestId = 1; // To find the matching request msg
-    repeated PartitionMetadataMsg partitionMetadata = 2;
-    optional BlockStateFromExecutor state = 3;
-}
-
-message ReservePartitionResponseMsg {
-    required int64 requestId = 1; // To find the matching request msg
-    optional int64 positionToWrite = 2;
-    optional int32 partitionIdx = 3;
-}
-
-// Messages from Executors to Master
-message CommitPartitionMsg {
-    required string blockId = 1;
-    repeated int32 partitionIdx = 2;
-}
-
-message ReservePartitionMsg {
-    required string executorId = 1;
-    required string blockId = 2;
-    required PartitionMetadataMsg partitionMetadata = 3;
-}
-
-message RemovePartitionMetadataMsg {
-    required string blockId = 1;
-}
-
-message RequestPartitionMetadataMsg {
-    required string executorId = 1;
-    required string blockId = 2;
-}
-
 // Common messages
-message PartitionMetadataMsg {
-    required bytes key = 1;
-    required int32 partitionSize = 2;
-    optional int64 offset = 3;
-    required int64 numElements = 4;
-}
-
 message Metric {
     required string metricKey = 1;
     required string metricValue = 2;

--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/BlockManagerWorker.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/BlockManagerWorker.java
@@ -191,18 +191,16 @@ public final class BlockManagerWorker {
    * @param blockId            of the block.
    * @param partitions         to save to a block.
    * @param blockStore         to store the block.
-   * @param commitPerPartition whether commit every partition write or not.
    * @return a {@link Optional} of the size of each written block.
    */
   public Optional<List<Long>> putPartitions(final String blockId,
                                             final Iterable<Partition> partitions,
-                                            final DataStoreProperty.Value blockStore,
-                                            final boolean commitPerPartition) {
+                                            final DataStoreProperty.Value blockStore) {
     LOG.info("PutPartitions: {}", blockId);
     final BlockStore store = getBlockStore(blockStore);
 
     try {
-      return store.putPartitions(blockId, (Iterable) partitions, commitPerPartition);
+      return store.putPartitions(blockId, (Iterable) partitions);
     } catch (final Exception e) {
       throw new BlockWriteException(e);
     }

--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/CoderManager.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/CoderManager.java
@@ -27,6 +27,9 @@ import java.util.concurrent.ConcurrentMap;
 public final class CoderManager {
   private final ConcurrentMap<String, Coder> runtimeEdgeIdToCoder = new ConcurrentHashMap<>();
 
+  /**
+   * Constructor.
+   */
   @Inject
   public CoderManager() {
   }

--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/DataUtil.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/DataUtil.java
@@ -14,6 +14,9 @@ import java.util.stream.StreamSupport;
  * Utility methods for data handling (e.g., (de)serialization).
  */
 public final class DataUtil {
+  /**
+   * Empty constructor.
+   */
   private DataUtil() {
     // Private constructor.
   }
@@ -44,8 +47,9 @@ public final class DataUtil {
    *
    * @param elementsInPartition the number of elements in this partition.
    * @param coder               the coder to decode the bytes.
-   * @param key           the key value of the result partition.
+   * @param key                 the key value of the result partition.
    * @param inputStream         the input stream which will return the data in the partition as bytes.
+   * @param <K>                 the key type of the partitions.
    * @return the list of deserialized elements.
    * @throws IOException if fail to deserialize.
    */
@@ -57,7 +61,7 @@ public final class DataUtil {
     for (int i = 0; i < elementsInPartition; i++) {
       deserializedData.add(coder.decode(inputStream));
     }
-    return new NonSerializedPartition(key, deserializedData);
+    return new NonSerializedPartition<>(key, deserializedData);
   }
 
   /**
@@ -65,6 +69,7 @@ public final class DataUtil {
    *
    * @param coder               the coder for serialization.
    * @param partitionsToConvert the partitions to convert.
+   * @param <K>                 the key type of the partitions.
    * @return the converted {@link SerializedPartition}s.
    * @throws IOException if fail to convert.
    */
@@ -72,13 +77,13 @@ public final class DataUtil {
       final Coder coder,
       final Iterable<NonSerializedPartition<K>> partitionsToConvert) throws IOException {
     final List<SerializedPartition<K>> serializedPartitions = new ArrayList<>();
-    for (final NonSerializedPartition partitionToConvert : partitionsToConvert) {
+    for (final NonSerializedPartition<K> partitionToConvert : partitionsToConvert) {
       try (final DirectByteArrayOutputStream bytesOutputStream = new DirectByteArrayOutputStream()) {
         final long elementsTotal = serializePartition(coder, partitionToConvert, bytesOutputStream);
         final byte[] serializedBytes = bytesOutputStream.getBufDirectly();
         final int actualLength = bytesOutputStream.getCount();
         serializedPartitions.add(
-            new SerializedPartition(partitionToConvert.getKey(), elementsTotal, serializedBytes, actualLength));
+            new SerializedPartition<>(partitionToConvert.getKey(), elementsTotal, serializedBytes, actualLength));
       }
     }
     return serializedPartitions;
@@ -89,6 +94,7 @@ public final class DataUtil {
    *
    * @param coder               the coder for deserialization.
    * @param partitionsToConvert the partitions to convert.
+   * @param <K>                 the key type of the partitions.
    * @return the converted {@link NonSerializedPartition}s.
    * @throws IOException if fail to convert.
    */
@@ -100,7 +106,7 @@ public final class DataUtil {
       final K key = partitionToConvert.getKey();
       try (final ByteArrayInputStream byteArrayInputStream =
                new ByteArrayInputStream(partitionToConvert.getData())) {
-        final NonSerializedPartition deserializePartition = deserializePartition(
+        final NonSerializedPartition<K> deserializePartition = deserializePartition(
             partitionToConvert.getElementsTotal(), coder, key, byteArrayInputStream);
         nonSerializedPartitions.add(deserializePartition);
       }
@@ -118,6 +124,18 @@ public final class DataUtil {
   public static String blockIdToFilePath(final String blockId,
                                          final String fileDirectory) {
     return fileDirectory + "/" + blockId;
+  }
+
+  /**
+   * Converts a block id to the corresponding metadata file path.
+   *
+   * @param blockId       the ID of the block.
+   * @param fileDirectory the directory of the target block file.
+   * @return the metadata file path of the partition.
+   */
+  public static String blockIdToMetaFilePath(final String blockId,
+                                             final String fileDirectory) {
+    return fileDirectory + "/" + blockId + "_meta";
   }
 
   /**

--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/block/Block.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/block/Block.java
@@ -73,6 +73,8 @@ public interface Block<K extends Serializable> {
 
   /**
    * Commits this block to prevent further write.
+   *
+   * @throws IOException if failed to commit.
    */
-  void commit();
+  void commit() throws IOException;
 }

--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/block/NonSerializedMemoryBlock.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/block/NonSerializedMemoryBlock.java
@@ -39,6 +39,11 @@ public final class NonSerializedMemoryBlock<K extends Serializable> implements B
   private final Coder coder;
   private volatile boolean committed;
 
+  /**
+   * Constructor.
+   *
+   * @param coder the {@link Coder}.
+   */
   public NonSerializedMemoryBlock(final Coder coder) {
     this.nonSerializedPartitions = new ArrayList<>();
     this.coder = coder;

--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/block/SerializedMemoryBlock.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/block/SerializedMemoryBlock.java
@@ -39,6 +39,11 @@ public final class SerializedMemoryBlock<K extends Serializable> implements Bloc
   private final Coder coder;
   private volatile boolean committed;
 
+  /**
+   * Constructor.
+   *
+   * @param coder the {@link Coder}.
+   */
   public SerializedMemoryBlock(final Coder coder) {
     this.coder = coder;
     serializedPartitions = new ArrayList<>();

--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/metadata/FileMetadata.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/metadata/FileMetadata.java
@@ -19,41 +19,24 @@ import java.io.IOException;
 import java.io.Serializable;
 
 /**
- * This class represents a metadata for a {@link edu.snu.onyx.runtime.executor.data.block.Block}.
+ * This interface represents a metadata for a {@link edu.snu.onyx.runtime.executor.data.block.Block}.
  * The writer and reader determine the status of a file block
  * (such as accessibility, how many bytes are written, etc.) by using this metadata.
  * @param <K> the key type of its partitions.
  */
-public abstract class FileMetadata<K extends Serializable> {
-
-  private final boolean partitionCommitPerWrite; // Whether need to commit partition per every block write or not.
-
-  protected FileMetadata(final boolean partitionCommitPerWrite) {
-    this.partitionCommitPerWrite = partitionCommitPerWrite;
-  }
+public interface FileMetadata<K extends Serializable> {
 
   /**
-   * Reserves the region for a partition and get the metadata for the partition.
-   * When a writer reserves the region (or space) of a file for a data partition,
-   * other writers will write their data after the region.
-   * Also, the readers will judge a data partition available after the partition is committed.
+   * Writes the metadata for a partition.
    *
    * @param key     the key of the partition.
    * @param partitionSize the size of the partition.
    * @param elementsTotal the number of elements in the partition.
-   * @return the {@link PartitionMetadata} having all given information, the partition offset, and the index.
    * @throws IOException if fail to append the partition metadata.
    */
-  public abstract PartitionMetadata<K> reservePartition(final K key,
-                                                     final int partitionSize,
-                                                     final long elementsTotal) throws IOException;
-
-  /**
-   * Notifies that some partitions are written.
-   *
-   * @param partitionMetadataToCommit the metadata of the partitions to commit.
-   */
-  public abstract void commitPartitions(final Iterable<PartitionMetadata> partitionMetadataToCommit);
+  void writePartitionMetadata(final K key,
+                              final int partitionSize,
+                              final long elementsTotal) throws IOException;
 
   /**
    * Gets a iterable containing the partition metadata of corresponding block.
@@ -61,24 +44,17 @@ public abstract class FileMetadata<K extends Serializable> {
    * @return the iterable containing the partition metadata.
    * @throws IOException if fail to get the iterable.
    */
-  public abstract Iterable<PartitionMetadata<K>> getPartitionMetadataIterable() throws IOException;
+  Iterable<PartitionMetadata<K>> getPartitionMetadataIterable() throws IOException;
 
   /**
    * Deletes the metadata.
    *
    * @throws IOException if fail to delete.
    */
-  public abstract void deleteMetadata() throws IOException;
-
-  /**
-   * @return whether commit every partition write or not.
-   */
-  public final boolean isPartitionCommitPerWrite() {
-    return partitionCommitPerWrite;
-  }
+  void deleteMetadata() throws IOException;
 
   /**
    * Notifies that all writes are finished for the block corresponding to this metadata.
    */
-  public abstract void commitBlock();
+  void commitBlock();
 }

--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/metadata/FileMetadata.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/metadata/FileMetadata.java
@@ -102,7 +102,7 @@ public abstract class FileMetadata<K extends Serializable> {
    * Set the commit value.
    * @param committed whether this block is committed or not.
    */
-  public final void setCommitted(final boolean committed) {
+  protected final void setCommitted(final boolean committed) {
     this.committed.set(committed);
   }
 }

--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/metadata/LocalFileMetadata.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/metadata/LocalFileMetadata.java
@@ -26,67 +26,48 @@ import java.util.*;
  * @param <K> the key type of its partitions.
  */
 @ThreadSafe
-public final class LocalFileMetadata<K extends Serializable> extends FileMetadata<K> {
+public final class LocalFileMetadata<K extends Serializable> implements FileMetadata<K> {
 
-  // When a writer reserves a file region for a partition to write,
-  // the metadata of the partition is stored in this queue.
-  // When a partition in this queue is committed, the committed partition is polled and go into the committed iterable.
-  private final Queue<PartitionMetadata> reservePartitionMetadataQue;
-  private final List<PartitionMetadata<K>> commitPartitionMetadataIterable; // The list of committed partition metadata.
+  private final List<PartitionMetadata<K>> partitionMetadataList; // The list of partition metadata.
   private volatile long writtenBytesCursor; // Indicates how many bytes are (at least, logically) written in the file.
-  private volatile int partitionCount;
   private volatile boolean committed;
 
-  public LocalFileMetadata(final boolean commitPerPartition) {
-    super(commitPerPartition);
-    this.reservePartitionMetadataQue = new ArrayDeque<>();
-    this.commitPartitionMetadataIterable = new ArrayList<>();
-    this.partitionCount = 0;
+  public LocalFileMetadata() {
+    this.partitionMetadataList = new ArrayList<>();
     this.writtenBytesCursor = 0;
     this.committed = false;
   }
 
   /**
    * Reserves the region for a partition and get the metadata for the partition.
-   * @see FileMetadata#reservePartition(Serializable, int, long)
+   * @see FileMetadata#writePartitionMetadata(Serializable, int, long)
    */
   @Override
-  public synchronized PartitionMetadata reservePartition(final K key,
-                                                         final int partitionSize,
-                                                         final long elementsTotal) throws IOException {
+  public synchronized void writePartitionMetadata(final K key,
+                                                  final int partitionSize,
+                                                  final long elementsTotal) throws IOException {
     if (committed) {
       throw new IOException("Cannot write a new block to a closed partition.");
     }
 
     final PartitionMetadata partitionMetadata =
-        new PartitionMetadata(partitionCount, key, partitionSize, writtenBytesCursor, elementsTotal);
-    reservePartitionMetadataQue.add(partitionMetadata);
-    partitionCount++;
+        new PartitionMetadata(partitionMetadataList.size(), key, partitionSize, writtenBytesCursor, elementsTotal);
+    partitionMetadataList.add(partitionMetadata);
     writtenBytesCursor += partitionSize;
-    return partitionMetadata;
-  }
-
-  /**
-   * Notifies that some partitions are written.
-   * @see FileMetadata#commitPartitions(Iterable)
-   */
-  @Override
-  public synchronized void commitPartitions(final Iterable<PartitionMetadata> partitionMetadataToCommit) {
-    partitionMetadataToCommit.forEach(PartitionMetadata::setCommitted);
-
-    while (!reservePartitionMetadataQue.isEmpty() && reservePartitionMetadataQue.peek().isCommitted()) {
-      // If the metadata in the top of the reserved queue is committed, move it to the committed metadata iterable.
-      commitPartitionMetadataIterable.add(reservePartitionMetadataQue.poll());
-    }
   }
 
   /**
    * Gets a iterable containing the partition metadata of corresponding block.
    * @see FileMetadata#getPartitionMetadataIterable()
+   * @throws IOException if this block is not committed yet.
    */
   @Override
-  public Iterable<PartitionMetadata<K>> getPartitionMetadataIterable() {
-    return Collections.unmodifiableCollection(commitPartitionMetadataIterable);
+  public Iterable<PartitionMetadata<K>> getPartitionMetadataIterable() throws IOException {
+    if (committed) {
+      return Collections.unmodifiableCollection(partitionMetadataList);
+    } else {
+      throw new IOException("This block is not committed yet.");
+    }
   }
 
   /**

--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/metadata/PartitionMetadata.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/metadata/PartitionMetadata.java
@@ -15,55 +15,60 @@
  */
 package edu.snu.onyx.runtime.executor.data.metadata;
 
+import java.io.Serializable;
+
 /**
  * This class represents a metadata for a partition.
  * @param <K> the key type of its partitions.
  */
-public final class PartitionMetadata<K> {
-  private final int partitionIdx;
+public final class PartitionMetadata<K extends Serializable> {
   private final K key;
   private final int partitionSize;
   private final long offset;
   private final long elementsTotal;
-  private volatile boolean committed;
 
-  public PartitionMetadata(final int partitionIdx,
-                           final K key,
+  /**
+   * Constructor.
+   *
+   * @param key           the key of this partition.
+   * @param partitionSize the size of this partition.
+   * @param offset        the offset of this partition.
+   * @param elementsTotal the total number of elements in this partition.
+   */
+  public PartitionMetadata(final K key,
                            final int partitionSize,
                            final long offset,
                            final long elementsTotal) {
-    this.partitionIdx = partitionIdx;
     this.key = key;
     this.partitionSize = partitionSize;
     this.offset = offset;
     this.elementsTotal = elementsTotal;
-    this.committed = false;
   }
 
-  boolean isCommitted() {
-    return committed;
-  }
-
-  void setCommitted() {
-    this.committed = true;
-  }
-
-  int getPartitionIdx() {
-    return partitionIdx;
-  }
-
+  /**
+   * @return the key of this partition.
+   */
   public K getKey() {
     return key;
   }
 
+  /**
+   * @return the size of this partition.
+   */
   public int getPartitionSize() {
     return partitionSize;
   }
 
+  /**
+   * @return the offset of this partition.
+   */
   public long getOffset() {
     return offset;
   }
 
+  /**
+   * @return the total number of elements in this partition.
+   */
   public long getElementsTotal() {
     return elementsTotal;
   }

--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/metadata/RemoteFileMetadata.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/metadata/RemoteFileMetadata.java
@@ -37,7 +37,7 @@ import java.util.concurrent.ExecutionException;
  * @param <K> the key type of its partitions.
  */
 @ThreadSafe
-public final class RemoteFileMetadata<K extends Serializable> extends FileMetadata<K> {
+public final class RemoteFileMetadata<K extends Serializable> implements FileMetadata<K> {
 
   private final String blockId;
   private final String executorId;
@@ -47,16 +47,13 @@ public final class RemoteFileMetadata<K extends Serializable> extends FileMetada
   /**
    * Opens a block metadata.
    *
-   * @param commitPerBlock     whether commit every block write or not.
    * @param blockId            the id of the block.
    * @param executorId         the id of the executor.
    * @param connectionToMaster the connection for sending messages to master.
    */
-  public RemoteFileMetadata(final boolean commitPerBlock,
-                            final String blockId,
+  public RemoteFileMetadata(final String blockId,
                             final String executorId,
                             final PersistentConnectionToMasterMap connectionToMaster) {
-    super(commitPerBlock);
     this.blockId = blockId;
     this.executorId = executorId;
     this.connectionToMaster = connectionToMaster;
@@ -65,12 +62,12 @@ public final class RemoteFileMetadata<K extends Serializable> extends FileMetada
   /**
    * Reserves the region for a partition and get the metadata for the partition.
    *
-   * @see  FileMetadata#reservePartition(Serializable, int, long)
+   * @see  FileMetadata#writePartitionMetadata(Serializable, int, long)
    */
   @Override
-  public synchronized PartitionMetadata reservePartition(final K key,
-                                                         final int partitionSize,
-                                                         final long elementsTotal) throws IOException {
+  public synchronized void writePartitionMetadata(final K key,
+                                                  final int partitionSize,
+                                                  final long elementsTotal) throws IOException {
     // Convert the block metadata to a block metadata message (without offset).
     final ControlMessage.PartitionMetadataMsg partitionMetadataMsg =
         ControlMessage.PartitionMetadataMsg.newBuilder()

--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/metadata/RemoteFileMetadata.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/metadata/RemoteFileMetadata.java
@@ -15,137 +15,47 @@
  */
 package edu.snu.onyx.runtime.executor.data.metadata;
 
-import com.google.protobuf.ByteString;
-import edu.snu.onyx.runtime.common.RuntimeIdGenerator;
-import edu.snu.onyx.runtime.common.comm.ControlMessage;
-import edu.snu.onyx.runtime.common.message.MessageEnvironment;
-import edu.snu.onyx.runtime.common.message.PersistentConnectionToMasterMap;
 import org.apache.commons.lang3.SerializationUtils;
 
 import javax.annotation.concurrent.ThreadSafe;
 import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 /**
  * This class represents a metadata for a remote file block.
  * Because the data is stored in a remote file and globally accessed by multiple nodes,
- * each access (create - write - close, read, or deletion) for a block needs one instance of this metadata.
- * These accesses are judiciously synchronized by the metadata server in master.
+ * each read, or deletion for a block needs one instance of this metadata.
+ * The metadata is store in and read from a file (after a remote file block is committed).
  * @param <K> the key type of its partitions.
  */
 @ThreadSafe
-public final class RemoteFileMetadata<K extends Serializable> implements FileMetadata<K> {
+public final class RemoteFileMetadata<K extends Serializable> extends FileMetadata<K> {
 
-  private final String blockId;
-  private final String executorId;
-  private final PersistentConnectionToMasterMap connectionToMaster;
-  private volatile Iterable<PartitionMetadata<K>> partitionMetadataIterable;
+  private final String metaFilePath;
 
   /**
-   * Opens a block metadata.
+   * Constructor for creating a non-committed new file metadata.
    *
-   * @param blockId            the id of the block.
-   * @param executorId         the id of the executor.
-   * @param connectionToMaster the connection for sending messages to master.
+   * @param metaFilePath the metadata file path.
    */
-  public RemoteFileMetadata(final String blockId,
-                            final String executorId,
-                            final PersistentConnectionToMasterMap connectionToMaster) {
-    this.blockId = blockId;
-    this.executorId = executorId;
-    this.connectionToMaster = connectionToMaster;
+  private RemoteFileMetadata(final String metaFilePath) {
+    super();
+    this.metaFilePath = metaFilePath;
   }
 
   /**
-   * Reserves the region for a partition and get the metadata for the partition.
+   * Constructor for opening a existing file metadata.
    *
-   * @see  FileMetadata#writePartitionMetadata(Serializable, int, long)
+   * @param metaFilePath          the metadata file path.
+   * @param partitionMetadataList the partition metadata list.
    */
-  @Override
-  public synchronized void writePartitionMetadata(final K key,
-                                                  final int partitionSize,
-                                                  final long elementsTotal) throws IOException {
-    // Convert the block metadata to a block metadata message (without offset).
-    final ControlMessage.PartitionMetadataMsg partitionMetadataMsg =
-        ControlMessage.PartitionMetadataMsg.newBuilder()
-            .setKey(ByteString.copyFrom(SerializationUtils.serialize(key)))
-            .setPartitionSize(partitionSize)
-            .setNumElements(elementsTotal)
-            .build();
-
-    // Send the partition metadata to the metadata server in the master and ask where to store the partition.
-    final CompletableFuture<ControlMessage.Message> reservePartitionResponseFuture =
-        connectionToMaster.getMessageSender(MessageEnvironment.BLOCK_MANAGER_MASTER_MESSAGE_LISTENER_ID).request(
-            ControlMessage.Message.newBuilder()
-                .setId(RuntimeIdGenerator.generateMessageId())
-                .setListenerId(MessageEnvironment.BLOCK_MANAGER_MASTER_MESSAGE_LISTENER_ID)
-                .setType(ControlMessage.MessageType.ReservePartition)
-                .setReservePartitionMsg(
-                    ControlMessage.ReservePartitionMsg.newBuilder()
-                        .setExecutorId(executorId)
-                        .setBlockId(blockId)
-                        .setPartitionMetadata(partitionMetadataMsg))
-                .build());
-
-    // Get the response from the metadata server.
-    final ControlMessage.Message responseFromMaster;
-    try {
-      responseFromMaster = reservePartitionResponseFuture.get();
-    } catch (final InterruptedException | ExecutionException e) {
-      throw new IOException(e);
-    }
-
-    assert (responseFromMaster.getType() == ControlMessage.MessageType.ReservePartitionResponse);
-    final ControlMessage.ReservePartitionResponseMsg reservePartitionResponseMsg =
-        responseFromMaster.getReservePartitionResponseMsg();
-    if (!reservePartitionResponseMsg.hasPositionToWrite()) {
-      throw new IOException("Cannot append the block metadata.");
-    }
-    final int partitionIdx = reservePartitionResponseMsg.getPartitionIdx();
-    final long positionToWrite = reservePartitionResponseMsg.getPositionToWrite();
-    return new PartitionMetadata(partitionIdx, key, partitionSize, positionToWrite, elementsTotal);
-  }
-
-  /**
-   * Notifies that some partitions are written.
-   *
-   * @see FileMetadata#commitPartitions(Iterable)
-   */
-  @Override
-  public synchronized void commitPartitions(final Iterable<PartitionMetadata> partitionMetadataToCommit) {
-    final List<Integer> partitionIndices = new ArrayList<>();
-    partitionMetadataToCommit.forEach(partitionMetadata -> {
-      partitionMetadata.setCommitted();
-      partitionIndices.add(partitionMetadata.getPartitionIdx());
-    });
-
-    // Notify that these partitions are committed to the metadata server.
-    connectionToMaster.getMessageSender(MessageEnvironment.BLOCK_MANAGER_MASTER_MESSAGE_LISTENER_ID).send(
-        ControlMessage.Message.newBuilder()
-            .setId(RuntimeIdGenerator.generateMessageId())
-            .setListenerId(MessageEnvironment.BLOCK_MANAGER_MASTER_MESSAGE_LISTENER_ID)
-            .setType(ControlMessage.MessageType.CommitPartition)
-            .setCommitPartitionMsg(
-                ControlMessage.CommitPartitionMsg.newBuilder()
-                    .setBlockId(blockId)
-                    .addAllPartitionIdx(partitionIndices))
-            .build());
-  }
-
-  /**
-   * Gets a iterable containing the partition metadata of corresponding blocks.
-   *
-   * @see FileMetadata#getPartitionMetadataIterable()
-   */
-  @Override
-  public synchronized Iterable<PartitionMetadata<K>> getPartitionMetadataIterable() throws IOException {
-    if (partitionMetadataIterable == null) {
-      partitionMetadataIterable = getPartitionMetadataFromServer();
-    }
-    return partitionMetadataIterable;
+  private RemoteFileMetadata(final String metaFilePath,
+                             final List<PartitionMetadata<K>> partitionMetadataList) {
+    super(partitionMetadataList);
+    this.metaFilePath = metaFilePath;
   }
 
   /**
@@ -153,82 +63,76 @@ public final class RemoteFileMetadata<K extends Serializable> implements FileMet
    */
   @Override
   public void deleteMetadata() throws IOException {
-    connectionToMaster.getMessageSender(MessageEnvironment.BLOCK_MANAGER_MASTER_MESSAGE_LISTENER_ID).send(
-        ControlMessage.Message.newBuilder()
-            .setId(RuntimeIdGenerator.generateMessageId())
-            .setListenerId(MessageEnvironment.BLOCK_MANAGER_MASTER_MESSAGE_LISTENER_ID)
-            .setType(ControlMessage.MessageType.RemovePartitionMetadata)
-            .setRemovePartitionMetadataMsg(
-                ControlMessage.RemovePartitionMetadataMsg.newBuilder()
-                    .setBlockId(blockId))
-            .build());
+    Files.delete(Paths.get(metaFilePath));
   }
 
   /**
+   * Write the collected {@link PartitionMetadata}s to the metadata file.
    * Notifies that all writes are finished for the block corresponding to this metadata.
    */
   @Override
-  public synchronized void commitBlock() {
-    // Handled by block manager master (via block commit message).
+  public synchronized void commitBlock() throws IOException {
+    final Iterable<PartitionMetadata<K>> partitionMetadataItr = getPartitionMetadataIterable();
+    try (
+        final FileOutputStream metafileOutputStream = new FileOutputStream(metaFilePath, false);
+        final DataOutputStream dataOutputStream = new DataOutputStream(metafileOutputStream)
+    ) {
+      for (PartitionMetadata<K> partitionMetadata : partitionMetadataItr) {
+        final byte[] key = SerializationUtils.serialize(partitionMetadata.getKey());
+        dataOutputStream.writeInt(key.length);
+        dataOutputStream.write(key);
+        dataOutputStream.writeInt(partitionMetadata.getPartitionSize());
+        dataOutputStream.writeLong(partitionMetadata.getOffset());
+        dataOutputStream.writeLong(partitionMetadata.getElementsTotal());
+      }
+    }
+    setCommitted(true);
   }
 
   /**
-   * Gets the iterable of partition metadata from the metadata server.
+   * Creates a new block metadata.
    *
-   * @return the received file metadata.
-   * @throws IOException if fail to get the metadata.
+   * @param metaFilePath the path of the file to write metadata.
+   * @param <T>          the key type of the block's partitions.
+   * @return the created block metadata.
    */
-  private Iterable<PartitionMetadata<K>> getPartitionMetadataFromServer() throws IOException {
-    final List<PartitionMetadata<K>> partitionMetadataList = new ArrayList<>();
+  public static <T extends Serializable> RemoteFileMetadata<T> create(final String metaFilePath) {
+    return new RemoteFileMetadata<>(metaFilePath);
+  }
 
-    // Ask the metadata server in the master for the metadata
-    final CompletableFuture<ControlMessage.Message> metadataResponseFuture =
-        connectionToMaster.getMessageSender(MessageEnvironment.BLOCK_MANAGER_MASTER_MESSAGE_LISTENER_ID).request(
-            ControlMessage.Message.newBuilder()
-                .setId(RuntimeIdGenerator.generateMessageId())
-                .setListenerId(MessageEnvironment.BLOCK_MANAGER_MASTER_MESSAGE_LISTENER_ID)
-                .setType(ControlMessage.MessageType.RequestPartitionMetadata)
-                .setRequestPartitionMetadataMsg(
-                    ControlMessage.RequestPartitionMetadataMsg.newBuilder()
-                        .setExecutorId(executorId)
-                        .setBlockId(blockId)
-                        .build())
-                .build());
-
-    final ControlMessage.Message responseFromMaster;
-    try {
-      responseFromMaster = metadataResponseFuture.get();
-    } catch (final InterruptedException | ExecutionException e) {
-      throw new IOException(e);
+  /**
+   * Opens a existing block metadata in file.
+   *
+   * @param metaFilePath the path of the file to write metadata.
+   * @param <T>          the key type of the block's partitions.
+   * @return the created block metadata.
+   * @throws IOException if fail to open.
+   */
+  public static <T extends Serializable> RemoteFileMetadata<T> open(final String metaFilePath) throws IOException {
+    if (!new File(metaFilePath).isFile()) {
+      throw new IOException("File " + metaFilePath + " does not exist!");
     }
+    final List<PartitionMetadata<T>> partitionMetadataList = new ArrayList<>();
+    try (
+        final FileInputStream metafileInputStream = new FileInputStream(metaFilePath);
+        final DataInputStream dataInputStream = new DataInputStream(metafileInputStream)
+    ) {
+      while (dataInputStream.available() > 0) {
+        final int keyLength = dataInputStream.readInt();
+        final byte[] desKey = new byte[keyLength];
+        if (keyLength != dataInputStream.read(desKey)) {
+          throw new IOException("Invalid key length!");
+        }
 
-    assert (responseFromMaster.getType() == ControlMessage.MessageType.MetadataResponse);
-    final ControlMessage.MetadataResponseMsg metadataResponseMsg = responseFromMaster.getMetadataResponseMsg();
-    if (metadataResponseMsg.hasState()) {
-      // Response has an exception state.
-      throw new IOException(new Throwable(
-          "Cannot get the metadata of block " + blockId + " from the metadata server: "
-              + "The block state is " + metadataResponseMsg.getState()));
-    }
-
-    // Construct the metadata from the response.
-    final List<ControlMessage.PartitionMetadataMsg> partitionMetadataMsgList =
-        metadataResponseMsg.getPartitionMetadataList();
-    for (int partitionIdx = 0; partitionIdx < partitionMetadataMsgList.size(); partitionIdx++) {
-      final ControlMessage.PartitionMetadataMsg partitionMetadataMsg = partitionMetadataMsgList.get(partitionIdx);
-      if (!partitionMetadataMsg.hasOffset()) {
-        throw new IOException(new Throwable(
-            "The metadata of a partition in the " + blockId + " does not have offset value."));
+        final PartitionMetadata<T> partitionMetadata = new PartitionMetadata<>(
+            SerializationUtils.deserialize(desKey),
+            dataInputStream.readInt(),
+            dataInputStream.readLong(),
+            dataInputStream.readLong()
+        );
+        partitionMetadataList.add(partitionMetadata);
       }
-      partitionMetadataList.add(new PartitionMetadata(
-          partitionIdx,
-          SerializationUtils.deserialize(partitionMetadataMsg.getKey().toByteArray()),
-          partitionMetadataMsg.getPartitionSize(),
-          partitionMetadataMsg.getOffset(),
-          partitionMetadataMsg.getNumElements()
-      ));
     }
-
-    return partitionMetadataList;
+    return new RemoteFileMetadata<>(metaFilePath, partitionMetadataList);
   }
 }

--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/stores/AbstractBlockStore.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/stores/AbstractBlockStore.java
@@ -26,6 +26,10 @@ import edu.snu.onyx.runtime.executor.data.CoderManager;
 public abstract class AbstractBlockStore implements BlockStore {
   private final CoderManager coderManager;
 
+  /**
+   * Constructor.
+   * @param coderManager the coder manager.
+   */
   protected AbstractBlockStore(final CoderManager coderManager) {
     this.coderManager = coderManager;
   }

--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/stores/BlockStore.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/stores/BlockStore.java
@@ -49,7 +49,6 @@ public interface BlockStore {
    *
    * @param blockId            of the block.
    * @param partitions         to save to a block.
-   * @param commitPerPartition whether commit every partition write or not.
    * @param <K> the key type of the partitions.
    * @return the size of the data per partition (only when the data is serialized).
    * @throws BlockWriteException for any error occurred while trying to write a block.
@@ -58,8 +57,7 @@ public interface BlockStore {
    *          have to be handled by the scheduler with fault tolerance mechanism.)
    */
   <K extends Serializable> Optional<List<Long>> putPartitions(String blockId,
-                                     Iterable<NonSerializedPartition<K>> partitions,
-                                     boolean commitPerPartition) throws BlockWriteException;
+                                     Iterable<NonSerializedPartition<K>> partitions) throws BlockWriteException;
 
   /**
    * Saves an iterable of {@link SerializedPartition}s to a block.
@@ -69,7 +67,6 @@ public interface BlockStore {
    *
    * @param blockId            of the block.
    * @param partitions         to save to a block.
-   * @param commitPerPartition whether commit every partition write or not.
    * @param <K> the key type of the partitions.
    * @return the size of the data per partition (only when the data is serialized).
    * @throws BlockWriteException for any error occurred while trying to write a block.
@@ -78,8 +75,7 @@ public interface BlockStore {
    *          have to be handled by the scheduler with fault tolerance mechanism.)
    */
   <K extends Serializable> List<Long> putSerializedPartitions(String blockId,
-                                     Iterable<SerializedPartition<K>> partitions,
-                                     boolean commitPerPartition) throws BlockWriteException;
+                                     Iterable<SerializedPartition<K>> partitions) throws BlockWriteException;
 
   /**
    * Retrieves {@link NonSerializedPartition}s.

--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/stores/BlockStore.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/stores/BlockStore.java
@@ -47,9 +47,9 @@ public interface BlockStore {
    * Invariant: This method may not support concurrent write for a single block.
    *            Only one thread have to write at once.
    *
-   * @param blockId            of the block.
-   * @param partitions         to save to a block.
-   * @param <K> the key type of the partitions.
+   * @param blockId    of the block.
+   * @param partitions to save to a block.
+   * @param <K>        the key type of the partitions.
    * @return the size of the data per partition (only when the data is serialized).
    * @throws BlockWriteException for any error occurred while trying to write a block.
    *         (This exception will be thrown to the scheduler
@@ -65,9 +65,9 @@ public interface BlockStore {
    * Invariant: This method may not support concurrent write for a single block.
    *            Only one thread have to write at once.
    *
-   * @param blockId            of the block.
-   * @param partitions         to save to a block.
-   * @param <K> the key type of the partitions.
+   * @param blockId    of the block.
+   * @param partitions to save to a block.
+   * @param <K>        the key type of the partitions.
    * @return the size of the data per partition (only when the data is serialized).
    * @throws BlockWriteException for any error occurred while trying to write a block.
    *         (This exception will be thrown to the scheduler
@@ -81,9 +81,9 @@ public interface BlockStore {
    * Retrieves {@link NonSerializedPartition}s.
    * They belong to a specific {@link edu.snu.onyx.runtime.common.data.KeyRange} from a block.
    *
-   * @param blockId   of the target partition.
+   * @param blockId  of the target partition.
    * @param keyRange the key range.
-   * @param <K> the key type of the partitions.
+   * @param <K>      the key type of the partitions.
    * @return the result elements from the target block (if the target block exists).
    * @throws BlockFetchException for any error occurred while trying to fetch a block.
    *         (This exception will be thrown to the scheduler
@@ -110,8 +110,6 @@ public interface BlockStore {
 
   /**
    * Notifies that all writes for a block is end.
-   * Subscribers waiting for the data of the target block are notified when the block is committed.
-   * Also, further subscription about a committed block will not blocked but get the data in it and finished.
    *
    * @param blockId of the block.
    * @throws BlockWriteException if fail to commit.

--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/stores/GlusterFileStore.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/stores/GlusterFileStore.java
@@ -20,8 +20,8 @@ import edu.snu.onyx.conf.JobConf;
 import edu.snu.onyx.common.coder.Coder;
 import edu.snu.onyx.common.exception.BlockWriteException;
 import edu.snu.onyx.runtime.common.data.KeyRange;
-import edu.snu.onyx.runtime.common.message.PersistentConnectionToMasterMap;
 import edu.snu.onyx.runtime.executor.data.*;
+import edu.snu.onyx.runtime.executor.data.block.Block;
 import edu.snu.onyx.runtime.executor.data.metadata.RemoteFileMetadata;
 import edu.snu.onyx.runtime.executor.data.block.FileBlock;
 import org.apache.reef.tang.annotations.Parameter;
@@ -32,30 +32,36 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Stores blocks in a mounted GlusterFS volume.
  * Because the data is stored in remote files and globally accessed by multiple nodes,
- * each access (write, read, or deletion) for a file needs one instance of {@link FileBlock}.
- * These accesses are judiciously synchronized by the metadata server in master.
+ * each read, or deletion for a file needs one instance of {@link FileBlock}.
+ * When a remote file block is created, it's metadata is maintained in memory until the block is committed.
+ * After the block is committed, the metadata is store in and read from a file.
  */
 @ThreadSafe
 public final class GlusterFileStore extends AbstractBlockStore implements RemoteFileStore {
+  private final Map<String, FileBlock> blockMap;
   private final String fileDirectory;
-  private final PersistentConnectionToMasterMap persistentConnectionToMasterMap;
-  private final String executorId;
 
+  /**
+   * Constructor.
+   *
+   * @param volumeDirectory the remote volume directory which will contain the files.
+   * @param jobId           the job id.
+   * @param coderManager    the coder manager.
+   */
   @Inject
   private GlusterFileStore(@Parameter(JobConf.GlusterVolumeDirectory.class) final String volumeDirectory,
                            @Parameter(JobConf.JobId.class) final String jobId,
-                           @Parameter(JobConf.ExecutorId.class) final String executorId,
-                           final CoderManager coderManager,
-                           final PersistentConnectionToMasterMap persistentConnectionToMasterMap) {
+                           final CoderManager coderManager) {
     super(coderManager);
+    this.blockMap = new ConcurrentHashMap<>();
     this.fileDirectory = volumeDirectory + "/" + jobId;
-    this.persistentConnectionToMasterMap = persistentConnectionToMasterMap;
-    this.executorId = executorId;
     new File(fileDirectory).mkdirs();
   }
 
@@ -68,23 +74,30 @@ public final class GlusterFileStore extends AbstractBlockStore implements Remote
   @Override
   public void createBlock(final String blockId) {
     removeBlock(blockId);
+    final Coder coder = getCoderFromWorker(blockId);
+    final String filePath = DataUtil.blockIdToFilePath(blockId, fileDirectory);
+    final RemoteFileMetadata metadata =
+        RemoteFileMetadata.create(DataUtil.blockIdToMetaFilePath(blockId, fileDirectory));
+    final FileBlock block = new FileBlock<>(coder, filePath, metadata);
+    blockMap.put(blockId, block);
   }
 
   /**
-   * Saves an iterable of data partitions to a block.
-   *
    * @see BlockStore#putPartitions(String, Iterable)
    */
   @Override
-  public <K extends Serializable> Optional<List<Long>> putPartitions(final String blockId,
-                                            final Iterable<NonSerializedPartition<K>> partitions)
+  public <K extends Serializable>
+  Optional<List<Long>> putPartitions(final String blockId,
+                                     final Iterable<NonSerializedPartition<K>> partitions)
       throws BlockWriteException {
     try {
-      final FileBlock block = createTmpBlock(blockId);
-      // Serialize and write the given blocks.
+      final Block<K> block = blockMap.get(blockId);
+      if (block == null) {
+        throw new BlockWriteException(new Throwable("The block " + blockId + "is not created yet."));
+      }
       return block.putPartitions(partitions);
     } catch (final IOException e) {
-      throw new BlockWriteException(e);
+      throw new BlockWriteException(new Throwable("Failed to store partitions to this block."));
     }
   }
 
@@ -92,15 +105,17 @@ public final class GlusterFileStore extends AbstractBlockStore implements Remote
    * @see BlockStore#putSerializedPartitions(String, Iterable)
    */
   @Override
-  public <K extends Serializable> List<Long> putSerializedPartitions(final String blockId,
-                                            final Iterable<SerializedPartition<K>> partitions)
-      throws BlockWriteException {
+  public <K extends Serializable>
+  List<Long> putSerializedPartitions(final String blockId,
+                                     final Iterable<SerializedPartition<K>> partitions) {
     try {
-      final FileBlock block = createTmpBlock(blockId);
-      // Write the given blocks.
+      final Block<K> block = blockMap.get(blockId);
+      if (block == null) {
+        throw new BlockWriteException(new Throwable("The block " + blockId + "is not created yet."));
+      }
       return block.putSerializedPartitions(partitions);
     } catch (final IOException e) {
-      throw new BlockWriteException(e);
+      throw new BlockWriteException(new Throwable("Failed to store partitions to this block."));
     }
   }
 
@@ -110,16 +125,16 @@ public final class GlusterFileStore extends AbstractBlockStore implements Remote
    * @see BlockStore#getPartitions(String, KeyRange)
    */
   @Override
-  public <K extends Serializable> Optional<Iterable<NonSerializedPartition<K>>> getPartitions(final String blockId,
-                                                                  final KeyRange<K> keyRange)
-      throws BlockFetchException {
+  public <K extends Serializable> Optional<Iterable<NonSerializedPartition<K>>> getPartitions(
+      final String blockId,
+      final KeyRange<K> keyRange) throws BlockFetchException {
     final String filePath = DataUtil.blockIdToFilePath(blockId, fileDirectory);
     if (!new File(filePath).isFile()) {
       return Optional.empty();
     } else {
       // Deserialize the target data in the corresponding file.
       try {
-        final FileBlock block = createTmpBlock(blockId);
+        final FileBlock<K> block = openBlockFromFile(blockId);
         final Iterable<NonSerializedPartition<K>> partitionsInRange = block.getPartitions(keyRange);
         return Optional.of(partitionsInRange);
       } catch (final IOException e) {
@@ -139,7 +154,7 @@ public final class GlusterFileStore extends AbstractBlockStore implements Remote
       return Optional.empty();
     } else {
       try {
-        final FileBlock block = createTmpBlock(blockId);
+        final FileBlock<K> block = openBlockFromFile(blockId);
         final Iterable<SerializedPartition<K>> partitionsInRange = block.getSerializedPartitions(keyRange);
         return Optional.of(partitionsInRange);
       } catch (final IOException e) {
@@ -149,16 +164,25 @@ public final class GlusterFileStore extends AbstractBlockStore implements Remote
   }
 
   /**
-   * @see BlockStore#commitBlock(String)
+   * Notifies that all writes for a block is end.
+   * Because the block and it's metadata is stored in a remote disk,
+   * this store does not have to maintain any information about the block.
+   *
+   * @param blockId the ID of the block to commit.
    */
   @Override
   public void commitBlock(final String blockId) throws BlockWriteException {
-    final Coder coder = getCoderFromWorker(blockId);
-    final String filePath = DataUtil.blockIdToFilePath(blockId, fileDirectory);
-
-    final RemoteFileMetadata metadata =
-        new RemoteFileMetadata(blockId, executorId, persistentConnectionToMasterMap);
-    new FileBlock(coder, filePath, metadata).commit();
+    final Block block = blockMap.get(blockId);
+    if (block != null) {
+      try {
+        block.commit();
+      } catch (final IOException e) {
+        throw new BlockWriteException(e);
+      }
+    } else {
+      throw new BlockWriteException(new Throwable("There isn't any block with id " + blockId));
+    }
+    blockMap.remove(blockId);
   }
 
   /**
@@ -173,7 +197,7 @@ public final class GlusterFileStore extends AbstractBlockStore implements Remote
 
     try {
       if (new File(filePath).isFile()) {
-        final FileBlock block = createTmpBlock(blockId);
+        final FileBlock block = openBlockFromFile(blockId);
         block.deleteFile();
         return true;
       } else {
@@ -194,7 +218,7 @@ public final class GlusterFileStore extends AbstractBlockStore implements Remote
 
     try {
       if (new File(filePath).isFile()) {
-        final FileBlock block = createTmpBlock(blockId);
+        final FileBlock block = openBlockFromFile(blockId);
         return block.asFileAreas(keyRange);
       } else {
         throw new BlockFetchException(new Throwable(String.format("%s does not exists", blockId)));
@@ -205,18 +229,20 @@ public final class GlusterFileStore extends AbstractBlockStore implements Remote
   }
 
   /**
-   * Creates a temporary {@link FileBlock} for a single access.
+   * Opens a temporary {@link FileBlock} for a single access from the block and it's metadata file.
    * Because the data is stored in remote files and globally accessed by multiple nodes,
-   * each access (write, read, or deletion) for a file needs one instance of {@link FileBlock}.
+   * each read, or deletion for a file needs one instance of {@link FileBlock}.
    *
-   * @param blockId            the ID of the block to create.
-   * @return the {@link FileBlock} created.
+   * @param blockId the ID of the block to open.
+   * @param <K>     the type of the key of the block.
+   * @return the {@link FileBlock} opened.
+   * @throws IOException if fail to open.
    */
-  private FileBlock createTmpBlock(final String blockId) {
+  private <K extends Serializable> FileBlock<K> openBlockFromFile(final String blockId) throws IOException {
     final Coder coder = getCoderFromWorker(blockId);
     final String filePath = DataUtil.blockIdToFilePath(blockId, fileDirectory);
-    final RemoteFileMetadata metadata = new RemoteFileMetadata(blockId, executorId, persistentConnectionToMasterMap);
-    final FileBlock block = new FileBlock(coder, filePath, metadata);
-    return block;
+    final RemoteFileMetadata<K> metadata =
+        RemoteFileMetadata.open(DataUtil.blockIdToMetaFilePath(blockId, fileDirectory));
+    return new FileBlock<>(coder, filePath, metadata);
   }
 }

--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/stores/LocalBlockStore.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/stores/LocalBlockStore.java
@@ -44,12 +44,12 @@ public abstract class LocalBlockStore extends AbstractBlockStore {
   }
 
   /**
-   * @see BlockStore#putPartitions(String, Iterable, boolean)
+   * @see BlockStore#putPartitions(String, Iterable)
    */
   @Override
   public final <K extends Serializable> Optional<List<Long>> putPartitions(final String blockId,
-                                                  final Iterable<NonSerializedPartition<K>> partitions,
-                                                  final boolean commitPerPartition) throws BlockWriteException {
+                                                  final Iterable<NonSerializedPartition<K>> partitions)
+      throws BlockWriteException {
     try {
       final Block block = blockMap.get(blockId);
       if (block == null) {
@@ -62,12 +62,11 @@ public abstract class LocalBlockStore extends AbstractBlockStore {
   }
 
   /**
-   * @see BlockStore#putSerializedPartitions(String, Iterable, boolean)
+   * @see BlockStore#putSerializedPartitions(String, Iterable)
    */
   @Override
   public final <K extends Serializable> List<Long> putSerializedPartitions(final String blockId,
-                                                  final Iterable<SerializedPartition<K>> partitions,
-                                                  final boolean commitPerPartition) {
+                                                  final Iterable<SerializedPartition<K>> partitions) {
     try {
       final Block block = blockMap.get(blockId);
       if (block == null) {

--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/stores/LocalBlockStore.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/stores/LocalBlockStore.java
@@ -26,6 +26,7 @@ import edu.snu.onyx.runtime.executor.data.block.Block;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -36,8 +37,13 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public abstract class LocalBlockStore extends AbstractBlockStore {
   // A map between block id and data blocks.
-  private final ConcurrentHashMap<String, Block> blockMap;
+  private final Map<String, Block> blockMap;
 
+  /**
+   * Constructor.
+   *
+   * @param coderManager the coder manager.
+   */
   protected LocalBlockStore(final CoderManager coderManager) {
     super(coderManager);
     this.blockMap = new ConcurrentHashMap<>();
@@ -47,11 +53,12 @@ public abstract class LocalBlockStore extends AbstractBlockStore {
    * @see BlockStore#putPartitions(String, Iterable)
    */
   @Override
-  public final <K extends Serializable> Optional<List<Long>> putPartitions(final String blockId,
-                                                  final Iterable<NonSerializedPartition<K>> partitions)
+  public final <K extends Serializable>
+  Optional<List<Long>> putPartitions(final String blockId,
+                                     final Iterable<NonSerializedPartition<K>> partitions)
       throws BlockWriteException {
     try {
-      final Block block = blockMap.get(blockId);
+      final Block<K> block = blockMap.get(blockId);
       if (block == null) {
         throw new BlockWriteException(new Throwable("The block " + blockId + "is not created yet."));
       }
@@ -65,10 +72,11 @@ public abstract class LocalBlockStore extends AbstractBlockStore {
    * @see BlockStore#putSerializedPartitions(String, Iterable)
    */
   @Override
-  public final <K extends Serializable> List<Long> putSerializedPartitions(final String blockId,
-                                                  final Iterable<SerializedPartition<K>> partitions) {
+  public final <K extends Serializable>
+  List<Long> putSerializedPartitions(final String blockId,
+                                     final Iterable<SerializedPartition<K>> partitions) {
     try {
-      final Block block = blockMap.get(blockId);
+      final Block<K> block = blockMap.get(blockId);
       if (block == null) {
         throw new BlockWriteException(new Throwable("The block " + blockId + "is not created yet."));
       }
@@ -84,7 +92,7 @@ public abstract class LocalBlockStore extends AbstractBlockStore {
   @Override
   public final <K extends Serializable>
   Optional<Iterable<NonSerializedPartition<K>>> getPartitions(final String blockId, final KeyRange<K> keyRange) {
-    final Block block = blockMap.get(blockId);
+    final Block<K> block = blockMap.get(blockId);
 
     if (block != null) {
       try {
@@ -104,7 +112,7 @@ public abstract class LocalBlockStore extends AbstractBlockStore {
   @Override
   public final <K extends Serializable>
   Optional<Iterable<SerializedPartition<K>>> getSerializedPartitions(final String blockId, final KeyRange<K> keyRange) {
-    final Block block = blockMap.get(blockId);
+    final Block<K> block = blockMap.get(blockId);
 
     if (block != null) {
       try {
@@ -125,7 +133,11 @@ public abstract class LocalBlockStore extends AbstractBlockStore {
   public final void commitBlock(final String blockId) {
     final Block block = blockMap.get(blockId);
     if (block != null) {
-      block.commit();
+      try {
+        block.commit();
+      } catch (final IOException e) {
+        throw new BlockWriteException(e);
+      }
     } else {
       throw new BlockWriteException(new Throwable("There isn't any block with id " + blockId));
     }
@@ -134,7 +146,7 @@ public abstract class LocalBlockStore extends AbstractBlockStore {
   /**
    * @return the map between the IDs and {@link Block}.
    */
-  public final ConcurrentHashMap<String, Block> getBlockMap() {
+  public final Map<String, Block> getBlockMap() {
     return blockMap;
   }
 }

--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/stores/LocalFileStore.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/stores/LocalFileStore.java
@@ -55,7 +55,7 @@ public final class LocalFileStore extends LocalBlockStore implements FileStore {
     removeBlock(blockId);
 
     final Coder coder = getCoderFromWorker(blockId);
-    final LocalFileMetadata metadata = new LocalFileMetadata(false);
+    final LocalFileMetadata metadata = new LocalFileMetadata();
 
     final FileBlock block =
         new FileBlock(coder, DataUtil.blockIdToFilePath(blockId, fileDirectory), metadata);

--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/stores/LocalFileStore.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/stores/LocalFileStore.java
@@ -36,6 +36,12 @@ import java.util.List;
 public final class LocalFileStore extends LocalBlockStore implements FileStore {
   private final String fileDirectory;
 
+  /**
+   * Constructor.
+   *
+   * @param fileDirectory the directory which will contain the files.
+   * @param coderManager  the coder manager.
+   */
   @Inject
   private LocalFileStore(@Parameter(JobConf.FileDirectory.class) final String fileDirectory,
                          final CoderManager coderManager) {

--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/stores/MemoryStore.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/stores/MemoryStore.java
@@ -28,11 +28,19 @@ import javax.inject.Inject;
 @ThreadSafe
 public final class MemoryStore extends LocalBlockStore {
 
+  /**
+   * Constructor.
+   *
+   * @param coderManager the coder manager.
+   */
   @Inject
   private MemoryStore(final CoderManager coderManager) {
     super(coderManager);
   }
 
+  /**
+   * @see BlockStore#createBlock(String)
+   */
   @Override
   public void createBlock(final String blockId) {
     final Coder coder = getCoderFromWorker(blockId);

--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/stores/SerializedMemoryStore.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/stores/SerializedMemoryStore.java
@@ -28,11 +28,18 @@ import javax.inject.Inject;
 @ThreadSafe
 public final class SerializedMemoryStore extends LocalBlockStore {
 
+  /**
+   * Constructor.
+   * @param coderManager the coder manager.
+   */
   @Inject
   private SerializedMemoryStore(final CoderManager coderManager) {
     super(coderManager);
   }
 
+  /**
+   * @see BlockStore#createBlock(String)
+   */
   @Override
   public void createBlock(final String blockId) {
     final Coder coder = getCoderFromWorker(blockId);

--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/datatransfer/OutputWriter.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/datatransfer/OutputWriter.java
@@ -125,8 +125,7 @@ public final class OutputWriter extends DataTransfer implements AutoCloseable {
 
   private void writeOneToOne(final List<Partition> partitionsToWrite) {
     // Write data.
-    blockManagerWorker.putPartitions(
-        blockId, partitionsToWrite, blockStoreValue, false);
+    blockManagerWorker.putPartitions(blockId, partitionsToWrite, blockStoreValue);
   }
 
   private void writeBroadcast(final List<Partition> partitionsToWrite) {
@@ -141,8 +140,7 @@ public final class OutputWriter extends DataTransfer implements AutoCloseable {
     }
 
     // Write data.
-    blockManagerWorker.putPartitions(
-        blockId, partitionsToWrite, blockStoreValue, false);
+    blockManagerWorker.putPartitions(blockId, partitionsToWrite, blockStoreValue);
   }
 
   /**
@@ -162,7 +160,7 @@ public final class OutputWriter extends DataTransfer implements AutoCloseable {
 
     // Write data.
     final Optional<List<Long>> partitionSizeInfo =
-        blockManagerWorker.putPartitions(blockId, partitionsToWrite, blockStoreValue, false);
+        blockManagerWorker.putPartitions(blockId, partitionsToWrite, blockStoreValue);
     if (partitionSizeInfo.isPresent()) {
       this.accumulatedPartitionSizeInfo.addAll(partitionSizeInfo.get());
     }

--- a/runtime/master/src/main/java/edu/snu/onyx/runtime/master/RuntimeMaster.java
+++ b/runtime/master/src/main/java/edu/snu/onyx/runtime/master/RuntimeMaster.java
@@ -153,7 +153,6 @@ public final class RuntimeMaster {
       scheduler.terminate();
       schedulerRunner.terminate();
       pendingTaskGroupQueue.close();
-      blockManagerMaster.terminate();
       masterMessageEnvironment.close();
 
       final Future<Boolean> allExecutorsClosed = containerManager.terminate();

--- a/tests/src/test/java/edu/snu/onyx/tests/runtime/executor/data/BlockStoreTest.java
+++ b/tests/src/test/java/edu/snu/onyx/tests/runtime/executor/data/BlockStoreTest.java
@@ -313,7 +313,7 @@ public final class BlockStoreTest {
               IntStream.range(writeTaskIdx, writeTaskIdx + 1).forEach(blockIdx -> {
                 final String blockId = blockIdList.get(blockIdx);
                 writerSideStore.createBlock(blockId);
-                writerSideStore.putPartitions(blockId, partitionsPerBlock.get(blockIdx), false);
+                writerSideStore.putPartitions(blockId, partitionsPerBlock.get(blockIdx));
                 writerSideStore.commitBlock(blockId);
                 blockManagerMaster.onBlockStateChanged(blockId, BlockState.State.COMMITTED,
                     "Writer side of the shuffle edge");
@@ -405,7 +405,7 @@ public final class BlockStoreTest {
       public Boolean call() {
         try {
           writerSideStore.createBlock(concBlockId);
-          writerSideStore.putPartitions(concBlockId, Collections.singleton(concBlockPartition), false);
+          writerSideStore.putPartitions(concBlockId, Collections.singleton(concBlockPartition));
           writerSideStore.commitBlock(concBlockId);
           blockManagerMaster.onBlockStateChanged(
               concBlockId, BlockState.State.COMMITTED, "Writer side of the concurrent read edge");
@@ -490,8 +490,7 @@ public final class BlockStoreTest {
             try {
               final String blockId = hashedBlockIdList.get(writeTaskIdx);
               writerSideStore.createBlock(blockId);
-              writerSideStore.putPartitions(blockId,
-                  hashedBlockPartitionList.get(writeTaskIdx), false);
+              writerSideStore.putPartitions(blockId, hashedBlockPartitionList.get(writeTaskIdx));
               writerSideStore.commitBlock(blockId);
               blockManagerMaster.onBlockStateChanged(blockId, BlockState.State.COMMITTED,
                   "Writer side of the shuffle in hash range edge");

--- a/tests/src/test/java/edu/snu/onyx/tests/runtime/executor/data/BlockStoreTest.java
+++ b/tests/src/test/java/edu/snu/onyx/tests/runtime/executor/data/BlockStoreTest.java
@@ -245,6 +245,7 @@ public final class BlockStoreTest {
    */
   @Test(timeout = 10000)
   public void testLocalFileStore() throws Exception {
+    FileUtils.deleteDirectory(new File(TMP_FILE_DIRECTORY));
     final Injector injector = Tang.Factory.getTang().newInjector();
     injector.bindVolatileParameter(JobConf.FileDirectory.class, TMP_FILE_DIRECTORY);
     injector.bindVolatileInstance(CoderManager.class, coderManager);
@@ -263,6 +264,7 @@ public final class BlockStoreTest {
    */
   @Test(timeout = 10000)
   public void testGlusterFileStore() throws Exception {
+    FileUtils.deleteDirectory(new File(TMP_FILE_DIRECTORY));
     final RemoteFileStore writerSideRemoteFileStore =
         createGlusterFileStore("writer");
     final RemoteFileStore readerSideRemoteFileStore =


### PR DESCRIPTION
This PR:
- makes `RemoteFileMetadata` be stored in remote file instead of memory in driver side.
  - when write a remote block, it's metadata (including partition information) is maintained in the memory of the executor which runs the task
  - when the block is committed, the metadata will be flushed into a separate remote file
  - when the block is read, the metadata will be restored from the file
- removes all message passing for metadata between driver & executor 

Resolves #715