### PR TITLE
[Onyx-719] Use Iterator (instead of Iterable) in InputReading and feeding Transform

### DIFF
--- a/common/src/main/java/edu/snu/onyx/common/ir/Reader.java
+++ b/common/src/main/java/edu/snu/onyx/common/ir/Reader.java
@@ -16,6 +16,7 @@
 package edu.snu.onyx.common.ir;
 
 import java.io.Serializable;
+import java.util.Iterator;
 
 /**
  * Interface for reader.
@@ -24,9 +25,9 @@ import java.io.Serializable;
 public interface Reader<O> extends Serializable {
   /**
    * Method to read data from the source.
-   * @return an Iterable of the data read by the reader.
+   * @return an {@link Iterator} of the data read by the reader.
    * @throws Exception exception while reading data.
    */
-  Iterable<O> read() throws Exception;
+  Iterator<O> read() throws Exception;
 }
 

--- a/common/src/main/java/edu/snu/onyx/common/ir/vertex/BoundedSourceVertex.java
+++ b/common/src/main/java/edu/snu/onyx/common/ir/vertex/BoundedSourceVertex.java
@@ -18,6 +18,7 @@ package edu.snu.onyx.common.ir.vertex;
 import edu.snu.onyx.common.ir.Reader;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -82,14 +83,14 @@ public final class BoundedSourceVertex<O> extends SourceVertex<O> {
     }
 
     @Override
-    public final Iterable<T> read() throws Exception {
+    public final Iterator<T> read() throws Exception {
       final ArrayList<T> elements = new ArrayList<>();
       try (Source.Reader<T> reader = boundedSource.createReader()) {
         for (boolean available = reader.start(); available; available = reader.advance()) {
           elements.add(reader.getCurrent());
         }
       }
-      return elements;
+      return elements.iterator();
     }
   }
 }

--- a/common/src/main/java/edu/snu/onyx/common/ir/vertex/transform/RelayTransform.java
+++ b/common/src/main/java/edu/snu/onyx/common/ir/vertex/transform/RelayTransform.java
@@ -17,6 +17,8 @@ package edu.snu.onyx.common.ir.vertex.transform;
 
 import edu.snu.onyx.common.ir.OutputCollector;
 
+import java.util.Iterator;
+
 /**
  * A {@link Transform} relays input data from upstream vertex to downstream vertex promptly.
  * This transform can be used for merging input data into the {@link OutputCollector}.
@@ -38,8 +40,8 @@ public final class RelayTransform<T> implements Transform<T, T> {
   }
 
   @Override
-  public void onData(final Iterable<T> elements, final String srcVertexId) {
-    elements.forEach(element -> outputCollector.emit(element));
+  public void onData(final Iterator<T> elements, final String srcVertexId) {
+    elements.forEachRemaining(element -> outputCollector.emit(element));
   }
 
   @Override

--- a/common/src/main/java/edu/snu/onyx/common/ir/vertex/transform/SailfishDecodingTransform.java
+++ b/common/src/main/java/edu/snu/onyx/common/ir/vertex/transform/SailfishDecodingTransform.java
@@ -20,6 +20,7 @@ import edu.snu.onyx.common.ir.OutputCollector;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.util.Iterator;
 
 /**
  * A {@link Transform} decodes input values into bytes and emits.
@@ -44,8 +45,8 @@ public final class SailfishDecodingTransform<T> implements Transform<byte[], T> 
   }
 
   @Override
-  public void onData(final Iterable<byte[]> elements, final String srcVertexId) {
-    elements.forEach(element -> {
+  public void onData(final Iterator<byte[]> elements, final String srcVertexId) {
+    elements.forEachRemaining(element -> {
       try (final ByteArrayInputStream inputStream = new ByteArrayInputStream(element)) {
         outputCollector.emit(coder.decode(inputStream));
       } catch (final IOException e) {

--- a/common/src/main/java/edu/snu/onyx/common/ir/vertex/transform/SailfishEncodingTransform.java
+++ b/common/src/main/java/edu/snu/onyx/common/ir/vertex/transform/SailfishEncodingTransform.java
@@ -20,6 +20,7 @@ import edu.snu.onyx.common.ir.OutputCollector;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.Iterator;
 
 /**
  * A {@link Transform} encodes input values into bytes and emits.
@@ -44,8 +45,8 @@ public final class SailfishEncodingTransform<T> implements Transform<T, byte[]> 
   }
 
   @Override
-  public void onData(final Iterable<T> elements, final String srcVertexId) {
-    elements.forEach(element -> {
+  public void onData(final Iterator<T> elements, final String srcVertexId) {
+    elements.forEachRemaining(element -> {
       try (final ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
         coder.encode(element, outputStream);
         outputCollector.emit(outputStream.toByteArray());

--- a/common/src/main/java/edu/snu/onyx/common/ir/vertex/transform/Transform.java
+++ b/common/src/main/java/edu/snu/onyx/common/ir/vertex/transform/Transform.java
@@ -18,6 +18,7 @@ package edu.snu.onyx.common.ir.vertex.transform;
 import edu.snu.onyx.common.ir.OutputCollector;
 
 import java.io.Serializable;
+import java.util.Iterator;
 import java.util.Map;
 
 /**
@@ -40,7 +41,7 @@ public interface Transform<I, O> extends Serializable {
    * @param elements data received.
    * @param srcVertexId sender of the data.
    */
-  void onData(Iterable<I> elements, String srcVertexId);
+  void onData(Iterator<I> elements, String srcVertexId);
 
   /**
    * Close the transform.

--- a/compiler/frontend-beam/src/main/java/edu/snu/onyx/compiler/frontend/beam/transform/BroadcastTransform.java
+++ b/compiler/frontend-beam/src/main/java/edu/snu/onyx/compiler/frontend/beam/transform/BroadcastTransform.java
@@ -21,6 +21,7 @@ import org.apache.beam.sdk.transforms.ViewFn;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.sdk.values.PCollectionView;
 
+import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -48,9 +49,10 @@ public final class BroadcastTransform<I, O> implements Transform<I, O> {
   }
 
   @Override
-  public void onData(final Iterable<I> elements, final String srcVertexId) {
+  public void onData(final Iterator<I> elements, final String srcVertexId) {
+    final Iterable<I> iterable = () -> elements;
     final List<WindowedValue<I>> windowed = StreamSupport
-        .stream((elements).spliterator(), false)
+        .stream(iterable.spliterator(), false)
         .map(element -> WindowedValue.valueInGlobalWindow(element))
         .collect(Collectors.toList());
     final ViewFn<Iterable<WindowedValue<I>>, O> viewFn = this.pCollectionView.getViewFn();

--- a/compiler/frontend-beam/src/main/java/edu/snu/onyx/compiler/frontend/beam/transform/DoTransform.java
+++ b/compiler/frontend-beam/src/main/java/edu/snu/onyx/compiler/frontend/beam/transform/DoTransform.java
@@ -34,6 +34,7 @@ import org.joda.time.Instant;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 
 /**
@@ -71,14 +72,14 @@ public final class DoTransform<I, O> implements Transform<I, O> {
   }
 
   @Override
-  public void onData(final Iterable<I> elements, final String srcVertexId) {
+  public void onData(final Iterator<I> elements, final String srcVertexId) {
     final StartBundleContext startBundleContext = new StartBundleContext(doFn, serializedOptions);
     final FinishBundleContext finishBundleContext = new FinishBundleContext(doFn, outputCollector, serializedOptions);
     final ProcessContext processContext = new ProcessContext(doFn, outputCollector, sideInputs, serializedOptions);
     final DoFnInvoker invoker = DoFnInvokers.invokerFor(doFn);
     invoker.invokeSetup();
     invoker.invokeStartBundle(startBundleContext);
-    elements.forEach(element -> { // No need to check for input index, since it is always 0 for DoTransform
+    elements.forEachRemaining(element -> { // No need to check for input index, since it is always 0 for DoTransform
       processContext.setElement(element);
       invoker.invokeProcessElement(processContext);
     });

--- a/compiler/frontend-beam/src/main/java/edu/snu/onyx/compiler/frontend/beam/transform/FlattenTransform.java
+++ b/compiler/frontend-beam/src/main/java/edu/snu/onyx/compiler/frontend/beam/transform/FlattenTransform.java
@@ -19,6 +19,7 @@ import edu.snu.onyx.common.ir.OutputCollector;
 import edu.snu.onyx.common.ir.vertex.transform.Transform;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 
 /**
  * Flatten transform implementation.
@@ -41,8 +42,8 @@ public final class FlattenTransform<T> implements Transform<T, T> {
   }
 
   @Override
-  public void onData(final Iterable<T> elements, final String srcVertexId) {
-    elements.forEach(collectedElements::add);
+  public void onData(final Iterator<T> elements, final String srcVertexId) {
+    elements.forEachRemaining(collectedElements::add);
   }
 
   @Override

--- a/compiler/frontend-beam/src/main/java/edu/snu/onyx/compiler/frontend/beam/transform/GroupByKeyTransform.java
+++ b/compiler/frontend-beam/src/main/java/edu/snu/onyx/compiler/frontend/beam/transform/GroupByKeyTransform.java
@@ -19,10 +19,7 @@ import edu.snu.onyx.common.ir.OutputCollector;
 import edu.snu.onyx.common.ir.vertex.transform.Transform;
 import org.apache.beam.sdk.values.KV;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Group Beam KVs.
@@ -45,8 +42,8 @@ public final class GroupByKeyTransform<I> implements Transform<I, KV<Object, Lis
   }
 
   @Override
-  public void onData(final Iterable<I> elements, final String srcVertexId) {
-    elements.forEach(element -> {
+  public void onData(final Iterator<I> elements, final String srcVertexId) {
+    elements.forEachRemaining(element -> {
       final KV kv = (KV) element;
       keyToValues.putIfAbsent(kv.getKey(), new ArrayList());
       keyToValues.get(kv.getKey()).add(kv.getValue());

--- a/compiler/frontend-beam/src/main/java/edu/snu/onyx/compiler/frontend/beam/transform/WindowTransform.java
+++ b/compiler/frontend-beam/src/main/java/edu/snu/onyx/compiler/frontend/beam/transform/WindowTransform.java
@@ -19,6 +19,8 @@ import edu.snu.onyx.common.ir.OutputCollector;
 import edu.snu.onyx.common.ir.vertex.transform.Transform;
 import org.apache.beam.sdk.transforms.windowing.WindowFn;
 
+import java.util.Iterator;
+
 /**
  * Windowing transform implementation.
  * This transform simply windows the given elements into finite windows according to a user-specified WindowTransform.
@@ -43,9 +45,9 @@ public final class WindowTransform<T> implements Transform<T, T> {
   }
 
   @Override
-  public void onData(final Iterable<T> elements, final String srcVertexId) {
+  public void onData(final Iterator<T> elements, final String srcVertexId) {
     // TODO #36: Actually assign windows
-    elements.forEach(element -> outputCollector.emit(element));
+    elements.forEachRemaining(element -> outputCollector.emit(element));
   }
 
   @Override

--- a/compiler/optimizer/src/main/java/edu/snu/onyx/compiler/optimizer/examples/EmptyComponents.java
+++ b/compiler/optimizer/src/main/java/edu/snu/onyx/compiler/optimizer/examples/EmptyComponents.java
@@ -23,6 +23,7 @@ import edu.snu.onyx.common.ir.vertex.transform.Transform;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -60,7 +61,7 @@ public class EmptyComponents {
     }
 
     @Override
-    public void onData(final Iterable<I> elements, final String srcVertexId) {
+    public void onData(final Iterator<I> elements, final String srcVertexId) {
     }
 
     @Override

--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/BlockManagerWorker.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/BlockManagerWorker.java
@@ -107,7 +107,7 @@ public final class BlockManagerWorker {
    * @param keyRange     the key range descriptor.
    * @return the result data in the block.
    */
-  public CompletableFuture<Iterable> retrieveDataFromBlock(
+  public CompletableFuture<Iterator> retrieveDataFromBlock(
       final String blockId,
       final String runtimeEdgeId,
       final DataStoreProperty.Value blockStore,
@@ -124,7 +124,8 @@ public final class BlockManagerWorker {
 
       // Block resides in this evaluator!
       try {
-        return CompletableFuture.completedFuture(DataUtil.concatNonSerPartitions(optionalResultPartitions.get()));
+        return CompletableFuture.completedFuture(DataUtil.concatNonSerPartitions(optionalResultPartitions.get())
+            .iterator());
       } catch (final IOException e) {
         throw new BlockFetchException(e);
       }
@@ -146,7 +147,7 @@ public final class BlockManagerWorker {
    * @param keyRange     the key range descriptor
    * @return the {@link CompletableFuture} of the block.
    */
-  private CompletableFuture<Iterable> requestBlockInRemoteWorker(
+  private CompletableFuture<Iterator> requestBlockInRemoteWorker(
       final String blockId,
       final String runtimeEdgeId,
       final DataStoreProperty.Value blockStore,
@@ -380,7 +381,7 @@ public final class BlockManagerWorker {
             outputStream.writeSerializedPartitions(optionalResult.get()).close();
             handleUsedData(blockStore, outputStream.getBlockId());
           } else {
-            final Iterable block =
+            final Iterator block =
                 retrieveDataFromBlock(outputStream.getBlockId(), outputStream.getRuntimeEdgeId(),
                     blockStore, outputStream.getKeyRange()).get();
             outputStream.writeElements(block).close();

--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/blocktransfer/BlockInputStream.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/blocktransfer/BlockInputStream.java
@@ -56,7 +56,7 @@ public final class BlockInputStream<T> implements Iterable<T>, BlockStream {
   private Coder<T> coder;
   private ExecutorService executorService;
 
-  private final CompletableFuture<BlockInputStream<T>> completeFuture = new CompletableFuture<>();
+  private final CompletableFuture<Iterator<T>> completeFuture = new CompletableFuture<>();
   private final ByteBufInputStream byteBufInputStream = new ByteBufInputStream();
   private final ClosableBlockingIterable<T> elementQueue = new ClosableBlockingIterable<>();
   private volatile boolean started = false;
@@ -153,7 +153,7 @@ public final class BlockInputStream<T> implements Iterable<T>, BlockStream {
         final long endTime = System.currentTimeMillis();
         elementQueue.close();
         if (!completeFuture.isCompletedExceptionally()) {
-          completeFuture.complete(this);
+          completeFuture.complete(iterator());
           // If encodePartialBlock option is on, the elapsed time is not only determined by the speed of decoder
           // but also by the rate of byte stream through the network.
           // Before investigating on low rate of decoding, check the rate of the byte stream.
@@ -239,7 +239,7 @@ public final class BlockInputStream<T> implements Iterable<T>, BlockStream {
    *
    * @return a {@link CompletableFuture} that completes with the block transfer being done
    */
-  public CompletableFuture<BlockInputStream<T>> getCompleteFuture() {
+  public CompletableFuture<Iterator<T>> getCompleteFuture() {
     return completeFuture;
   }
 

--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/blocktransfer/BlockOutputStream.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/blocktransfer/BlockOutputStream.java
@@ -32,6 +32,7 @@ import java.io.OutputStream;
 import java.nio.channels.FileChannel;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Iterator;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -181,9 +182,10 @@ public final class BlockOutputStream<T> implements AutoCloseable, BlockStream {
             // end of output stream
             byteBufOutputStream.close();
             break;
-          } else if (thing instanceof Iterable) {
-            for (final T element : (Iterable<T>) thing) {
-              coder.encode(element, byteBufOutputStream);
+          } else if (thing instanceof Iterator) {
+            final Iterator<T> iterator = (Iterator<T>) thing;
+            while (iterator.hasNext()) {
+              coder.encode(iterator.next(), byteBufOutputStream);
             }
           } else if (thing instanceof FileArea) {
             byteBufOutputStream.writeFileArea((FileArea) thing);
@@ -220,14 +222,14 @@ public final class BlockOutputStream<T> implements AutoCloseable, BlockStream {
   /**
    * Writes a {@link Iterable} of elements.
    *
-   * @param iterable the {@link Iterable} to write
+   * @param iterator the {@link Iterator} to write
    * @return {@link BlockOutputStream} (i.e. {@code this})
    * @throws IOException           if an exception was set
    * @throws IllegalStateException if this stream is closed already
    */
-  public BlockOutputStream writeElements(final Iterable iterable) throws IOException {
+  public BlockOutputStream writeElements(final Iterator iterator) throws IOException {
     checkWritableCondition();
-    elementQueue.put(iterable);
+    elementQueue.put(iterator);
     if (encodePartialBlock) {
       startEncodingThreadIfNeeded();
     }

--- a/tests/src/test/java/edu/snu/onyx/tests/runtime/executor/TaskGroupExecutorTest.java
+++ b/tests/src/test/java/edu/snu/onyx/tests/runtime/executor/TaskGroupExecutorTest.java
@@ -117,8 +117,8 @@ public final class TaskGroupExecutorTest {
 
     final Reader sourceReader = new Reader() {
       @Override
-      public Iterable read() throws Exception {
-        return elements;
+      public Iterator read() throws Exception {
+        return elements.iterator();
       }
     };
     final BoundedSourceTask<Integer> boundedSourceTask =
@@ -217,8 +217,8 @@ public final class TaskGroupExecutorTest {
     @Override
     public InputReader answer(final InvocationOnMock invocationOnMock) throws Throwable {
       // Read the data.
-      final List<CompletableFuture<Iterable>> inputFutures = new ArrayList<>();
-      inputFutures.add(CompletableFuture.completedFuture(elements));
+      final List<CompletableFuture<Iterator>> inputFutures = new ArrayList<>();
+      inputFutures.add(CompletableFuture.completedFuture(elements.iterator()));
       final InputReader inputReader = mock(InputReader.class);
       when(inputReader.read()).thenReturn(inputFutures);
       when(inputReader.isSideInputReader()).thenReturn(false);
@@ -234,11 +234,11 @@ public final class TaskGroupExecutorTest {
   private class InterStageReaderAnswer implements Answer<InputReader> {
     @Override
     public InputReader answer(final InvocationOnMock invocationOnMock) throws Throwable {
-      final List<CompletableFuture<Iterable>> inputFutures = new ArrayList<>(SOURCE_PARALLELISM);
+      final List<CompletableFuture<Iterator>> inputFutures = new ArrayList<>(SOURCE_PARALLELISM);
       final int elementsPerSource = DATA_SIZE / SOURCE_PARALLELISM;
       for (int i = 0; i < SOURCE_PARALLELISM; i++) {
         inputFutures.add(CompletableFuture.completedFuture(
-            elements.subList(i * elementsPerSource, (i + 1) * elementsPerSource)));
+            elements.subList(i * elementsPerSource, (i + 1) * elementsPerSource).iterator()));
       }
       final InputReader inputReader = mock(InputReader.class);
       when(inputReader.read()).thenReturn(inputFutures);
@@ -295,8 +295,8 @@ public final class TaskGroupExecutorTest {
     }
 
     @Override
-    public void onData(final Iterable<T> elements, final String srcVertexId) {
-      elements.forEach(element -> outputCollector.emit(element));
+    public void onData(final Iterator<T> elements, final String srcVertexId) {
+      elements.forEachRemaining(element -> outputCollector.emit(element));
     }
 
     @Override

--- a/tests/src/test/java/edu/snu/onyx/tests/runtime/executor/datatransfer/DataTransferTest.java
+++ b/tests/src/test/java/edu/snu/onyx/tests/runtime/executor/datatransfer/DataTransferTest.java
@@ -322,7 +322,7 @@ public final class DataTransferTest {
 
       final List dataRead = new ArrayList<>();
       try {
-        InputReader.combineFutures(reader.read()).forEach(dataRead::add);
+        InputReader.combineFutures(reader.read()).forEachRemaining(dataRead::add);
       } catch (final Exception e) {
         throw new RuntimeException(e);
       }


### PR DESCRIPTION
Use `Iterator` to represent input data and intermeidate data for TaskGroup.

While executing a TaskGroup, the stream of data elements 'flows' from the input source through the series of Tasks. The data flow keeps moving forward and never goes back. For that reason, it would be better to use `Iterator` instead of `Iterable` to represent the collection of input data to be processed.

Resolves #719 