### PR TITLE
[Onyx-743] Split Source in Executor Instead of Driver

### DIFF
--- a/common/src/main/java/edu/snu/onyx/common/ir/Readable.java
+++ b/common/src/main/java/edu/snu/onyx/common/ir/Readable.java
@@ -16,7 +16,6 @@
 package edu.snu.onyx.common.ir;
 
 import java.io.Serializable;
-import java.util.Iterator;
 
 /**
  * Interface for readable.
@@ -25,9 +24,9 @@ import java.util.Iterator;
 public interface Readable<O> extends Serializable {
   /**
    * Method to read data from the source.
-   * @return an {@link Iterator} of the data read by the readable.
+   * @return an {@link Iterable} of the data read by the readable.
    * @throws Exception exception while reading data.
    */
-  Iterator<O> read() throws Exception;
+  Iterable<O> read() throws Exception;
 }
 

--- a/common/src/main/java/edu/snu/onyx/common/ir/Readable.java
+++ b/common/src/main/java/edu/snu/onyx/common/ir/Readable.java
@@ -13,22 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.onyx.common.ir.vertex;
+package edu.snu.onyx.common.ir;
 
-import edu.snu.onyx.common.ir.ReadablesWrapper;
+import java.io.Serializable;
+import java.util.Iterator;
 
 /**
- * IRVertex that reads data from an external source.
- * It is to be implemented in the compiler frontend with source-specific data fetching logic.
+ * Interface for readable.
  * @param <O> output type.
  */
-public abstract class SourceVertex<O> extends IRVertex {
-
+public interface Readable<O> extends Serializable {
   /**
-   * Gets parallel readable wrapper.
-   * @param desiredNumOfSplits number of splits desired.
-   * @return the wrapper for a list of readers.
-   * @throws Exception if fail to get.
+   * Method to read data from the source.
+   * @return an {@link Iterator} of the data read by the readable.
+   * @throws Exception exception while reading data.
    */
-  public abstract ReadablesWrapper<O> getReadableWrapper(int desiredNumOfSplits) throws Exception;
+  Iterator<O> read() throws Exception;
 }
+

--- a/common/src/main/java/edu/snu/onyx/common/ir/ReadablesWrapper.java
+++ b/common/src/main/java/edu/snu/onyx/common/ir/ReadablesWrapper.java
@@ -16,18 +16,18 @@
 package edu.snu.onyx.common.ir;
 
 import java.io.Serializable;
-import java.util.Iterator;
+import java.util.List;
 
 /**
- * Interface for reader.
+ * A wrapper interface for parallel {@link Readable}s.
  * @param <O> output type.
  */
-public interface Reader<O> extends Serializable {
+public interface ReadablesWrapper<O> extends Serializable {
+
   /**
-   * Method to read data from the source.
-   * @return an {@link Iterator} of the data read by the reader.
-   * @throws Exception exception while reading data.
+   * @return the parallel {@link Readable}s.
+   * @throws Exception if fail to get.
    */
-  Iterator<O> read() throws Exception;
+  List<Readable<O>> getReadables() throws Exception;
 }
 

--- a/common/src/main/java/edu/snu/onyx/common/ir/vertex/BoundedSourceVertex.java
+++ b/common/src/main/java/edu/snu/onyx/common/ir/vertex/BoundedSourceVertex.java
@@ -18,7 +18,6 @@ package edu.snu.onyx.common.ir.vertex;
 import edu.snu.onyx.common.ir.Readable;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 import edu.snu.onyx.common.ir.ReadablesWrapper;
@@ -105,14 +104,14 @@ public final class BoundedSourceVertex<O> extends SourceVertex<O> {
     }
 
     @Override
-    public Iterator<T> read() throws Exception {
+    public Iterable<T> read() throws Exception {
       final ArrayList<T> elements = new ArrayList<>();
       try (Source.Reader<T> reader = boundedSource.createReader()) {
         for (boolean available = reader.start(); available; available = reader.advance()) {
           elements.add(reader.getCurrent());
         }
       }
-      return elements.iterator();
+      return elements;
     }
   }
 }

--- a/common/src/main/java/edu/snu/onyx/common/ir/vertex/BoundedSourceVertex.java
+++ b/common/src/main/java/edu/snu/onyx/common/ir/vertex/BoundedSourceVertex.java
@@ -15,11 +15,13 @@
  */
 package edu.snu.onyx.common.ir.vertex;
 
-import edu.snu.onyx.common.ir.Reader;
+import edu.snu.onyx.common.ir.Readable;
 
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+
+import edu.snu.onyx.common.ir.ReadablesWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,13 +49,8 @@ public final class BoundedSourceVertex<O> extends SourceVertex<O> {
   }
 
   @Override
-  public List<Reader<O>> getReaders(final int desiredNumOfSplits) throws Exception {
-    final List<Reader<O>> readers = new ArrayList<>();
-    LOG.info("estimate: {}", source.getEstimatedSizeBytes());
-    LOG.info("desired: {}", desiredNumOfSplits);
-    source.split(source.getEstimatedSizeBytes() / desiredNumOfSplits).forEach(boundedSource ->
-        readers.add(new BoundedSourceReader<>(boundedSource)));
-    return readers;
+  public ReadablesWrapper<O> getReadableWrapper(final int desiredNumOfSplits) throws Exception {
+    return new BoundedSourceReadablesWrapper(desiredNumOfSplits);
   }
 
   @Override
@@ -68,22 +65,47 @@ public final class BoundedSourceVertex<O> extends SourceVertex<O> {
   }
 
   /**
-   * BoundedSourceReader class.
+   * A ReadablesWrapper for BoundedSourceVertex.
+   */
+  private final class BoundedSourceReadablesWrapper implements ReadablesWrapper<O> {
+    final int desiredNumOfSplits;
+
+    /**
+     * Constructor of the BoundedSourceReadablesWrapper.
+     * @param desiredNumOfSplits the number of splits desired.
+     */
+    private BoundedSourceReadablesWrapper(final int desiredNumOfSplits) {
+      this.desiredNumOfSplits = desiredNumOfSplits;
+    }
+
+    @Override
+    public List<Readable<O>> getReadables() throws Exception {
+      final List<Readable<O>> readables = new ArrayList<>();
+      LOG.info("estimate: {}", source.getEstimatedSizeBytes());
+      LOG.info("desired: {}", desiredNumOfSplits);
+      source.split(source.getEstimatedSizeBytes() / desiredNumOfSplits).forEach(boundedSource ->
+          readables.add(new BoundedSourceReadable<>(boundedSource)));
+      return readables;
+    }
+  }
+
+  /**
+   * BoundedSourceReadable class.
    * @param <T> type.
    */
-  public class BoundedSourceReader<T> implements Reader<T> {
+  private final class BoundedSourceReadable<T> implements Readable<T> {
     private final Source<T> boundedSource;
 
     /**
-     * Constructor of the BoundedSourceReader.
+     * Constructor of the BoundedSourceReadable.
      * @param boundedSource the BoundedSource.
      */
-    BoundedSourceReader(final Source<T> boundedSource) {
+    BoundedSourceReadable(final Source<T> boundedSource) {
       this.boundedSource = boundedSource;
     }
 
     @Override
-    public final Iterator<T> read() throws Exception {
+    public Iterator<T> read() throws Exception {
       final ArrayList<T> elements = new ArrayList<>();
       try (Source.Reader<T> reader = boundedSource.createReader()) {
         for (boolean available = reader.start(); available; available = reader.advance()) {

--- a/common/src/main/java/edu/snu/onyx/common/ir/vertex/InitializedSourceVertex.java
+++ b/common/src/main/java/edu/snu/onyx/common/ir/vertex/InitializedSourceVertex.java
@@ -15,7 +15,8 @@
  */
 package edu.snu.onyx.common.ir.vertex;
 
-import edu.snu.onyx.common.ir.Reader;
+import edu.snu.onyx.common.ir.Readable;
+import edu.snu.onyx.common.ir.ReadablesWrapper;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -44,44 +45,64 @@ public final class InitializedSourceVertex<T> extends SourceVertex<T> {
   }
 
   @Override
-  public List<Reader<T>> getReaders(final int desiredNumOfSplits) throws Exception {
-    final List<Reader<T>> readers = new ArrayList<>();
-    final long sliceSize = initializedSourceData.spliterator().getExactSizeIfKnown() / desiredNumOfSplits;
-    final Iterator<T> iterator = initializedSourceData.iterator();
-
-    for (int i = 0; i < desiredNumOfSplits; i++) {
-      final List<T> dataForReader = new ArrayList<>();
-
-      if (i == desiredNumOfSplits - 1) { // final iteration
-        iterator.forEachRemaining(dataForReader::add);
-      } else {
-        for (int j = 0; j < sliceSize && iterator.hasNext(); j++) {
-          dataForReader.add(iterator.next());
-        }
-      }
-
-      readers.add(new InitializedSourceReader<>(dataForReader));
-    }
-    return readers;
+  public ReadablesWrapper<T> getReadableWrapper(final int desiredNumOfSplits) throws Exception {
+    return new InitializedSourceReadablesWrapper(desiredNumOfSplits);
   }
 
   /**
-   * Reader for initialized source vertex. It simply returns the initialized data.
+   * A ReadablesWrapper for InitializedSourceVertex.
+   */
+  private final class InitializedSourceReadablesWrapper implements ReadablesWrapper<T> {
+    final int desiredNumOfSplits;
+
+    /**
+     * Constructor of the InitializedSourceReadablesWrapper.
+     * @param desiredNumOfSplits the number of splits desired.
+     */
+    private InitializedSourceReadablesWrapper(final int desiredNumOfSplits) {
+      this.desiredNumOfSplits = desiredNumOfSplits;
+    }
+
+    @Override
+    public List<Readable<T>> getReadables() throws Exception {
+      final List<Readable<T>> readables = new ArrayList<>();
+      final long sliceSize = initializedSourceData.spliterator().getExactSizeIfKnown() / desiredNumOfSplits;
+      final Iterator<T> iterator = initializedSourceData.iterator();
+
+      for (int i = 0; i < desiredNumOfSplits; i++) {
+        final List<T> dataForReader = new ArrayList<>();
+
+        if (i == desiredNumOfSplits - 1) { // final iteration
+          iterator.forEachRemaining(dataForReader::add);
+        } else {
+          for (int j = 0; j < sliceSize && iterator.hasNext(); j++) {
+            dataForReader.add(iterator.next());
+          }
+        }
+
+        readables.add(new InitializedSourceReadable<>(dataForReader));
+      }
+      return readables;
+    }
+  }
+
+  /**
+   * Readable for initialized source vertex. It simply returns the initialized data.
    * @param <T> type of the initial data.
    */
-  public class InitializedSourceReader<T> implements Reader<T> {
+  private final class InitializedSourceReadable<T> implements Readable<T> {
     private final Iterable<T> initializedSourceData;
 
     /**
      * Constructor.
      * @param initializedSourceData the source data.
      */
-    InitializedSourceReader(final Iterable<T> initializedSourceData) {
+    private InitializedSourceReadable(final Iterable<T> initializedSourceData) {
       this.initializedSourceData = initializedSourceData;
     }
 
     @Override
-    public final Iterator<T> read() throws Exception {
+    public Iterator<T> read() throws Exception {
       return this.initializedSourceData.iterator();
     }
   }

--- a/common/src/main/java/edu/snu/onyx/common/ir/vertex/InitializedSourceVertex.java
+++ b/common/src/main/java/edu/snu/onyx/common/ir/vertex/InitializedSourceVertex.java
@@ -102,8 +102,8 @@ public final class InitializedSourceVertex<T> extends SourceVertex<T> {
     }
 
     @Override
-    public Iterator<T> read() throws Exception {
-      return this.initializedSourceData.iterator();
+    public Iterable<T> read() throws Exception {
+      return this.initializedSourceData;
     }
   }
 }

--- a/common/src/main/java/edu/snu/onyx/common/ir/vertex/Source.java
+++ b/common/src/main/java/edu/snu/onyx/common/ir/vertex/Source.java
@@ -44,7 +44,7 @@ public interface Source<T> extends Serializable {
   long getEstimatedSizeBytes() throws Exception;
 
   /**
-   * @return a new Reader that reads from this source.
+   * @return a new Readable that reads from this source.
    * @throws IOException exception while reading.
    */
   Source.Reader<T> createReader() throws IOException;
@@ -82,7 +82,7 @@ public interface Source<T> extends Serializable {
     T getCurrent() throws NoSuchElementException;
 
     /**
-     * @return a source describing the same input that this Reader reads.
+     * @return a source describing the same input that this Readable reads.
      */
     Source<T> getCurrentSource();
   }

--- a/compiler/optimizer/src/main/java/edu/snu/onyx/compiler/optimizer/pass/compiletime/annotating/DefaultParallelismPass.java
+++ b/compiler/optimizer/src/main/java/edu/snu/onyx/compiler/optimizer/pass/compiletime/annotating/DefaultParallelismPass.java
@@ -69,7 +69,8 @@ public final class DefaultParallelismPass extends AnnotatingPass {
           // After that, we set the parallelism as the number of split readers.
           // (It can be more/less than the desired value.)
           final SourceVertex sourceVertex = (SourceVertex) vertex;
-          vertex.setProperty(ParallelismProperty.of(sourceVertex.getReaders(desiredSourceParallelism).size()));
+          vertex.setProperty(ParallelismProperty.of(
+              sourceVertex.getReadableWrapper(desiredSourceParallelism).getReadables().size()));
         } else if (!inEdges.isEmpty()) {
           // No reason to propagate via Broadcast edges, as the data streams that will use the broadcasted data
           // as a sideInput will have their own number of parallelism

--- a/examples/spark/src/test/java/edu/snu/onyx/examples/spark/SparkPiITCase.java
+++ b/examples/spark/src/test/java/edu/snu/onyx/examples/spark/SparkPiITCase.java
@@ -31,7 +31,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 @PrepareForTest(JobLauncher.class)
 public final class SparkPiITCase {
   private static final int TIMEOUT = 60000;
-  private static final String numParallelism = "10";
+  private static final String numParallelism = "3";
 
   private static ArgBuilder builder = new ArgBuilder()
       .addJobId(SparkPiITCase.class.getSimpleName())

--- a/runtime/common/src/main/java/edu/snu/onyx/runtime/common/RuntimeIdGenerator.java
+++ b/runtime/common/src/main/java/edu/snu/onyx/runtime/common/RuntimeIdGenerator.java
@@ -31,6 +31,9 @@ public final class RuntimeIdGenerator {
   private static String blockPrefix = "Block-";
   private static String blockIdSplitter = "_";
 
+  /**
+   * Private constructor which will not be used.
+   */
   private RuntimeIdGenerator() {
   }
 

--- a/runtime/common/src/main/java/edu/snu/onyx/runtime/common/plan/physical/BoundedSourceTask.java
+++ b/runtime/common/src/main/java/edu/snu/onyx/runtime/common/plan/physical/BoundedSourceTask.java
@@ -15,36 +15,38 @@
  */
 package edu.snu.onyx.runtime.common.plan.physical;
 
-import edu.snu.onyx.common.ir.Reader;
+import edu.snu.onyx.common.ir.Readable;
+import edu.snu.onyx.common.ir.ReadablesWrapper;
 
 /**
  * BoundedSourceTask.
  * @param <O> the output type.
  */
 public final class BoundedSourceTask<O> extends Task {
-  private final Reader<O> reader;
+  private final ReadablesWrapper<O> readableWrapper;
 
   /**
    * Constructor.
    * @param taskId id of the task.
    * @param runtimeVertexId id of the runtime vertex.
    * @param index index in its taskGroup.
-   * @param reader reader for the source data.
+   * @param readablesWrapper the wrapper of the readables for the source data.
    * @param taskGroupId id of the taskGroup.
    */
   public BoundedSourceTask(final String taskId,
                            final String runtimeVertexId,
                            final int index,
-                           final Reader<O> reader,
+                           final ReadablesWrapper<O> readablesWrapper,
                            final String taskGroupId) {
     super(taskId, runtimeVertexId, index, taskGroupId);
-    this.reader = reader;
+    this.readableWrapper = readablesWrapper;
   }
 
   /**
-   * @return the reader of source data.
+   * @return the readable of source data.
+   * @throws Exception if fail to get.
    */
-  public Reader getReader() {
-    return reader;
+  public Readable<O> getReadable() throws Exception {
+    return readableWrapper.getReadables().get(getIndex());
   }
 }

--- a/runtime/common/src/main/java/edu/snu/onyx/runtime/common/plan/physical/PhysicalPlanGenerator.java
+++ b/runtime/common/src/main/java/edu/snu/onyx/runtime/common/plan/physical/PhysicalPlanGenerator.java
@@ -15,11 +15,11 @@
  */
 package edu.snu.onyx.runtime.common.plan.physical;
 
+import edu.snu.onyx.common.ir.ReadablesWrapper;
 import edu.snu.onyx.common.ir.vertex.*;
 import edu.snu.onyx.conf.JobConf;
 import edu.snu.onyx.common.dag.DAG;
 import edu.snu.onyx.common.dag.DAGBuilder;
-import edu.snu.onyx.common.ir.Reader;
 import edu.snu.onyx.common.ir.edge.IREdge;
 import edu.snu.onyx.common.ir.executionproperty.ExecutionPropertyMap;
 import edu.snu.onyx.common.ir.executionproperty.ExecutionProperty;
@@ -206,13 +206,9 @@ public final class PhysicalPlanGenerator
             final SourceVertex sourceVertex = (SourceVertex) irVertex;
 
             try {
-              final List<Reader> readers = sourceVertex.getReaders(stageParallelism);
-              if (readers.size() != stageParallelism) {
-                throw new RuntimeException("Actual parallelism differs from the one specified by IR: "
-                    + readers.size() + " and " + stageParallelism);
-              }
+              final ReadablesWrapper readables = sourceVertex.getReadableWrapper(stageParallelism);
               newTaskToAdd = new BoundedSourceTask<>(RuntimeIdGenerator.generateTaskId(), sourceVertex.getId(),
-                  taskGroupIndex, readers.get(taskGroupIndex), taskGroupId);
+                  taskGroupIndex, readables, taskGroupId);
             } catch (Exception e) {
               throw new PhysicalPlanGenerationException(e);
             }

--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/TaskGroupExecutor.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/TaskGroupExecutor.java
@@ -19,7 +19,7 @@ import edu.snu.onyx.common.ContextImpl;
 import edu.snu.onyx.common.Pair;
 import edu.snu.onyx.common.exception.BlockFetchException;
 import edu.snu.onyx.common.exception.BlockWriteException;
-import edu.snu.onyx.common.ir.Reader;
+import edu.snu.onyx.common.ir.Readable;
 import edu.snu.onyx.common.ir.vertex.transform.Transform;
 import edu.snu.onyx.common.ir.vertex.OperatorVertex;
 import edu.snu.onyx.runtime.common.plan.RuntimeEdge;
@@ -200,8 +200,8 @@ public final class TaskGroupExecutor {
    * @throws Exception occurred during input read.
    */
   private void launchBoundedSourceTask(final BoundedSourceTask boundedSourceTask) throws Exception {
-    final Reader reader = boundedSourceTask.getReader();
-    final Iterator readData = reader.read();
+    final Readable readable = boundedSourceTask.getReadable();
+    final Iterator readData = readable.read();
     final List iterable = new ArrayList<>();
     readData.forEachRemaining(iterable::add);
 

--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/TaskGroupExecutor.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/TaskGroupExecutor.java
@@ -201,12 +201,10 @@ public final class TaskGroupExecutor {
    */
   private void launchBoundedSourceTask(final BoundedSourceTask boundedSourceTask) throws Exception {
     final Readable readable = boundedSourceTask.getReadable();
-    final Iterator readData = readable.read();
-    final List iterable = new ArrayList<>();
-    readData.forEachRemaining(iterable::add);
+    final Iterable readData = readable.read();
 
     taskIdToOutputWriterMap.get(boundedSourceTask.getId()).forEach(outputWriter -> {
-      outputWriter.write(iterable);
+      outputWriter.write(readData);
       outputWriter.close();
     });
   }

--- a/tests/src/test/java/edu/snu/onyx/tests/runtime/executor/TaskGroupExecutorTest.java
+++ b/tests/src/test/java/edu/snu/onyx/tests/runtime/executor/TaskGroupExecutorTest.java
@@ -122,8 +122,8 @@ public final class TaskGroupExecutorTest {
         return Collections.singletonList(
             new Readable() {
               @Override
-              public Iterator read() throws Exception {
-                return elements.iterator();
+              public Iterable read() throws Exception {
+                return elements;
               }
             });
       }

--- a/tests/src/test/java/edu/snu/onyx/tests/runtime/executor/TaskGroupExecutorTest.java
+++ b/tests/src/test/java/edu/snu/onyx/tests/runtime/executor/TaskGroupExecutorTest.java
@@ -19,7 +19,8 @@ import edu.snu.onyx.common.coder.Coder;
 import edu.snu.onyx.common.dag.DAG;
 import edu.snu.onyx.common.dag.DAGBuilder;
 import edu.snu.onyx.common.ir.OutputCollector;
-import edu.snu.onyx.common.ir.Reader;
+import edu.snu.onyx.common.ir.Readable;
+import edu.snu.onyx.common.ir.ReadablesWrapper;
 import edu.snu.onyx.common.ir.vertex.transform.Transform;
 import edu.snu.onyx.common.ir.edge.executionproperty.DataStoreProperty;
 import edu.snu.onyx.common.ir.executionproperty.ExecutionPropertyMap;
@@ -115,14 +116,21 @@ public final class TaskGroupExecutorTest {
     final String taskGroupId = RuntimeIdGenerator.generateTaskGroupId();
     final String stageId = RuntimeIdGenerator.generateStageId(0);
 
-    final Reader sourceReader = new Reader() {
+    final ReadablesWrapper readablesWrapper = new ReadablesWrapper() {
       @Override
-      public Iterator read() throws Exception {
-        return elements.iterator();
+      public List<Readable> getReadables() throws Exception {
+        return Collections.singletonList(
+            new Readable() {
+              @Override
+              public Iterator read() throws Exception {
+                return elements.iterator();
+              }
+            });
       }
     };
+
     final BoundedSourceTask<Integer> boundedSourceTask =
-        new BoundedSourceTask<>(sourceTaskId, sourceIrVertexId, 0, sourceReader, taskGroupId);
+        new BoundedSourceTask<>(sourceTaskId, sourceIrVertexId, 0, readablesWrapper, taskGroupId);
 
     final DAG<Task, RuntimeEdge<Task>> taskDag =
         new DAGBuilder<Task, RuntimeEdge<Task>>().addVertex(boundedSourceTask).build();


### PR DESCRIPTION
This PR:
- implements `ReadablesWrapper` which contains the `Readable`s in a singleton (but not split yet).
- gives `ReadablesWrapper` to the `SourceVertex` (instead of each `Readable` instance)
- splits the `Readable`s from the `ReadablesWrapper` in `TaskGroupExecutor`.

(I've added `ReadablesWrapper` instead of changing `Source` class, because the class is planned to be removed by @wonook.)