### PR TITLE
[Minor] Iterables to iterators when writing outputs

### DIFF
--- a/common/src/main/java/edu/snu/onyx/common/ir/Readable.java
+++ b/common/src/main/java/edu/snu/onyx/common/ir/Readable.java
@@ -16,6 +16,7 @@
 package edu.snu.onyx.common.ir;
 
 import java.io.Serializable;
+import java.util.Iterator;
 
 /**
  * Interface for readable.
@@ -24,9 +25,9 @@ import java.io.Serializable;
 public interface Readable<O> extends Serializable {
   /**
    * Method to read data from the source.
-   * @return an {@link Iterable} of the data read by the readable.
+   * @return an {@link Iterator} of the data read by the readable.
    * @throws Exception exception while reading data.
    */
-  Iterable<O> read() throws Exception;
+  Iterator<O> read() throws Exception;
 }
 

--- a/common/src/main/java/edu/snu/onyx/common/ir/vertex/BoundedSourceVertex.java
+++ b/common/src/main/java/edu/snu/onyx/common/ir/vertex/BoundedSourceVertex.java
@@ -17,7 +17,6 @@ package edu.snu.onyx.common.ir.vertex;
 
 import edu.snu.onyx.common.ir.Readable;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -107,42 +106,13 @@ public final class BoundedSourceVertex<O> extends SourceVertex<O> {
 
     @Override
     public Iterator<T> read() throws Exception {
-      return new BoundedSourceIterator<>(boundedSource.createReader());
-    }
-  }
-
-  /**
-   * Iterator for the bounded source reader.
-   * @param <T> type of the data.
-   */
-  private final class BoundedSourceIterator<T> implements Iterator<T> {
-    private final Source.Reader<T> reader;
-    private boolean available;
-
-    /**
-     * Constructor.
-     * @param reader reader to read from.
-     * @throws Exception exceptions.
-     */
-    private BoundedSourceIterator(final Source.Reader<T> reader) throws Exception {
-      this.reader = reader;
-      this.available = reader.start();
-    }
-
-    @Override
-    public boolean hasNext() {
-      return available;
-    }
-
-    @Override
-    public T next() {
-      final T value = reader.getCurrent();
-      try {
-        available = reader.advance();
-      } catch (IOException e) {
-        throw new RuntimeException(e);
+      final ArrayList<T> elements = new ArrayList<>();
+      try (Source.Reader<T> reader = boundedSource.createReader()) {
+        for (boolean available = reader.start(); available; available = reader.advance()) {
+          elements.add(reader.getCurrent());
+        }
       }
-      return value;
+      return elements.iterator();
     }
   }
 }

--- a/common/src/main/java/edu/snu/onyx/common/ir/vertex/InitializedSourceVertex.java
+++ b/common/src/main/java/edu/snu/onyx/common/ir/vertex/InitializedSourceVertex.java
@@ -102,8 +102,8 @@ public final class InitializedSourceVertex<T> extends SourceVertex<T> {
     }
 
     @Override
-    public Iterable<T> read() throws Exception {
-      return this.initializedSourceData;
+    public Iterator<T> read() throws Exception {
+      return this.initializedSourceData.iterator();
     }
   }
 }

--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/TaskGroupExecutor.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/TaskGroupExecutor.java
@@ -320,14 +320,14 @@ public final class TaskGroupExecutor {
           inputReader.read().forEach(compFuture -> compFuture.thenAccept(dataQueue::add));
         });
 
-    final Iterator[] iterators = new Iterator[sourceParallelism.get()];
-    IntStream.range(0, sourceParallelism.get()).forEach(srcTaskNum -> {
-      try {
-        iterators[srcTaskNum] = (dataQueue.take());
-      } catch (final InterruptedException e) {
-        throw new BlockFetchException(e);
-      }
-    });
+    final Iterator[] iterators = IntStream.range(0, sourceParallelism.get())
+        .mapToObj(srcTaskNum -> {
+          try {
+            return dataQueue.take();
+          } catch (InterruptedException e) {
+            throw new BlockFetchException(e);
+          }
+        }).toArray(Iterator[]::new);
     physicalTaskIdToOutputWriterMap.get(physicalTaskId).forEach(outputWriter -> {
           outputWriter.write(Iterators.concat(iterators));
           outputWriter.close();

--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/BlockManagerWorker.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/BlockManagerWorker.java
@@ -122,8 +122,7 @@ public final class BlockManagerWorker {
 
       // Block resides in this evaluator!
       try {
-        return CompletableFuture.completedFuture(DataUtil.concatNonSerPartitions(optionalResultPartitions.get())
-            .iterator());
+        return CompletableFuture.completedFuture(DataUtil.concatNonSerPartitions(optionalResultPartitions.get()));
       } catch (final IOException e) {
         throw new BlockFetchException(e);
       }

--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/NonSerializedPartition.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/NonSerializedPartition.java
@@ -15,14 +15,16 @@
  */
 package edu.snu.onyx.runtime.executor.data;
 
+import java.util.Iterator;
+
 /**
  * A collection of data elements. The data is stored as an iterable of elements.
  * This is a unit of read / write towards {@link edu.snu.onyx.runtime.executor.data.block.Block}s.
  * @param <K> the key type of its partitions.
  */
-public final class NonSerializedPartition<K> implements Partition<Iterable, K> {
+public final class NonSerializedPartition<K> implements Partition<Iterator<Object>, K> {
   private final K key;
-  private final Iterable nonSerializedData;
+  private final Iterator<Object> nonSerializedData;
 
   /**
    * Creates a non-serialized {@link Partition} having a specific key value.
@@ -31,7 +33,7 @@ public final class NonSerializedPartition<K> implements Partition<Iterable, K> {
    * @param data the non-serialized data.
    */
   public NonSerializedPartition(final K key,
-                                final Iterable data) {
+                                final Iterator<Object> data) {
     this.key = key;
     this.nonSerializedData = data;
   }
@@ -56,7 +58,7 @@ public final class NonSerializedPartition<K> implements Partition<Iterable, K> {
    * @return the non-serialized data.
    */
   @Override
-  public Iterable getData() {
+  public Iterator<Object> getData() {
     return nonSerializedData;
   }
 }

--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/partitioner/IntactPartitioner.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/partitioner/IntactPartitioner.java
@@ -20,6 +20,7 @@ import edu.snu.onyx.runtime.executor.data.NonSerializedPartition;
 import edu.snu.onyx.runtime.executor.data.Partition;
 
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -29,7 +30,7 @@ import java.util.List;
 public final class IntactPartitioner implements Partitioner {
 
   @Override
-  public List<Partition> partition(final Iterable elements,
+  public List<Partition> partition(final Iterator elements,
                                    final int dstParallelism,
                                    final KeyExtractor keyExtractor) {
     return Collections.singletonList(new NonSerializedPartition(0, elements));

--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/partitioner/Partitioner.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/data/partitioner/Partitioner.java
@@ -18,6 +18,7 @@ package edu.snu.onyx.runtime.executor.data.partitioner;
 import edu.snu.onyx.common.KeyExtractor;
 import edu.snu.onyx.runtime.executor.data.Partition;
 
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -35,5 +36,5 @@ public interface Partitioner {
    * @param keyExtractor   extracts keys from elements.
    * @return the list of partitioned blocks.
    */
-  List<Partition> partition(Iterable elements, int dstParallelism, KeyExtractor keyExtractor);
+  List<Partition> partition(Iterator elements, int dstParallelism, KeyExtractor keyExtractor);
 }

--- a/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/datatransfer/OutputWriter.java
+++ b/runtime/executor/src/main/java/edu/snu/onyx/runtime/executor/datatransfer/OutputWriter.java
@@ -71,7 +71,7 @@ public final class OutputWriter extends DataTransfer implements AutoCloseable {
    *
    * @param dataToWrite An iterable for the elements to be written.
    */
-  public void write(final Iterable dataToWrite) {
+  public void write(final Iterator dataToWrite) {
     final Boolean isDataSizeMetricCollectionEdge = MetricCollectionProperty.Value.DataSkewRuntimePass
         .equals(runtimeEdge.getProperty(ExecutionProperty.Key.MetricCollection));
 

--- a/tests/src/test/java/edu/snu/onyx/tests/runtime/RuntimeTestUtil.java
+++ b/tests/src/test/java/edu/snu/onyx/tests/runtime/RuntimeTestUtil.java
@@ -248,7 +248,7 @@ public final class RuntimeTestUtil {
    * @return the list of elements.
    */
   public static List getRangedNumList(final int start,
-                                               final int end) {
+                                      final int end) {
     final List numList = new ArrayList<>(end - start);
     IntStream.range(start, end).forEach(number -> numList.add(KV.of(number, number)));
     return numList;

--- a/tests/src/test/java/edu/snu/onyx/tests/runtime/executor/TaskGroupExecutorTest.java
+++ b/tests/src/test/java/edu/snu/onyx/tests/runtime/executor/TaskGroupExecutorTest.java
@@ -122,8 +122,8 @@ public final class TaskGroupExecutorTest {
         return Collections.singletonList(
             new Readable() {
               @Override
-              public Iterable read() throws Exception {
-                return elements;
+              public Iterator read() throws Exception {
+                return elements.iterator();
               }
             });
       }

--- a/tests/src/test/java/edu/snu/onyx/tests/runtime/executor/datatransfer/DataTransferTest.java
+++ b/tests/src/test/java/edu/snu/onyx/tests/runtime/executor/datatransfer/DataTransferTest.java
@@ -297,7 +297,7 @@ public final class DataTransferTest {
       final List dataWritten = getRangedNumList(0, PARALLELISM_TEN);
       final OutputWriter writer = new OutputWriter(HASH_RANGE_MULTIPLIER, srcTaskIndex, srcVertex.getId(), dstVertex,
           dummyEdge, sender);
-      writer.write(dataWritten);
+      writer.write(dataWritten.iterator());
       writer.close();
       dataWrittenList.add(dataWritten);
     });


### PR DESCRIPTION
This PR:

- Fixes the iterables used at reading source data and writing output data to iterators to prevent OOMs and later support stream data.