### PR TITLE
[NEMO-787] Pack Block Location Request Messaging

### DIFF
--- a/compiler/frontend/spark/src/main/java/edu/snu/nemo/compiler/frontend/spark/sql/Dataset.java
+++ b/compiler/frontend/spark/src/main/java/edu/snu/nemo/compiler/frontend/spark/sql/Dataset.java
@@ -16,9 +16,12 @@
 package edu.snu.nemo.compiler.frontend.spark.sql;
 
 import edu.snu.nemo.compiler.frontend.spark.core.java.JavaRDD;
+import org.apache.spark.api.java.function.MapFunction;
+import org.apache.spark.api.java.function.MapPartitionsFunction;
 import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Encoder;
 import org.apache.spark.sql.Row;
+import org.apache.spark.sql.TypedColumn;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.storage.StorageLevel;
 
@@ -31,9 +34,10 @@ import java.util.stream.Stream;
 public final class Dataset<T> extends org.apache.spark.sql.Dataset<T> implements NemoSparkUserFacingClass {
   /**
    * Constructor.
+   *
    * @param sparkSession spark session.
-   * @param logicalPlan spark logical plan.
-   * @param encoder spark encoder.
+   * @param logicalPlan  spark logical plan.
+   * @param encoder      spark encoder.
    */
   private Dataset(final SparkSession sparkSession, final LogicalPlan logicalPlan, final Encoder<T> encoder) {
     super(sparkSession, logicalPlan, encoder);
@@ -41,8 +45,9 @@ public final class Dataset<T> extends org.apache.spark.sql.Dataset<T> implements
 
   /**
    * Using the immutable property of datasets, we can downcast spark datasets to our class using this function.
+   *
    * @param dataset the Spark dataset.
-   * @param <U> type of the dataset.
+   * @param <U>     type of the dataset.
    * @return our dataset class.
    */
   public static <U> Dataset<U> from(final org.apache.spark.sql.Dataset<U> dataset) {
@@ -55,10 +60,16 @@ public final class Dataset<T> extends org.apache.spark.sql.Dataset<T> implements
 
   /**
    * Create a javaRDD component from this data set.
+   *
    * @return the new javaRDD component.
    */
   @Override
   public JavaRDD<T> javaRDD() {
+    return this.toJavaRDD();
+  }
+
+  @Override
+  public JavaRDD<T> toJavaRDD() {
     return JavaRDD.of((SparkSession) super.sparkSession(), this);
   }
 
@@ -115,6 +126,14 @@ public final class Dataset<T> extends org.apache.spark.sql.Dataset<T> implements
   public Dataset<T> alias(final scala.Symbol alias) {
     final boolean userTriggered = initializeFunction(alias);
     final Dataset<T> result = from(super.alias(alias));
+    this.setIsUserTriggered(userTriggered);
+    return result;
+  }
+
+  @Override
+  public <U> Dataset<U> as(final Encoder<U> evidence) {
+    final boolean userTriggered = initializeFunction(evidence);
+    final Dataset<U> result = from(super.as(evidence));
     this.setIsUserTriggered(userTriggered);
     return result;
   }
@@ -377,10 +396,45 @@ public final class Dataset<T> extends org.apache.spark.sql.Dataset<T> implements
     return result;
   }
 
+  @Override
+  public <U> Dataset<U> map(final scala.Function1<T, U> func, final Encoder<U> evidence) {
+    final boolean userTriggered = initializeFunction(func, evidence);
+    final Dataset<U> result = from(super.map(func, evidence));
+    this.setIsUserTriggered(userTriggered);
+    return result;
+  }
+
+  @Override
+  public <U> Dataset<U> map(final MapFunction<T, U> func, final Encoder<U> encoder) {
+    final boolean userTriggered = initializeFunction(func, encoder);
+    final Dataset<U> result = from(super.map(func, encoder));
+    this.setIsUserTriggered(userTriggered);
+    return result;
+  }
+
+  @Override
+  public <U> Dataset<U> mapPartitions(
+      final scala.Function1<scala.collection.Iterator<T>, scala.collection.Iterator<U>> func,
+      final Encoder<U> evidence) {
+    final boolean userTriggered = initializeFunction(func, evidence);
+    final Dataset<U> result = from(super.mapPartitions(func, evidence));
+    this.setIsUserTriggered(userTriggered);
+    return result;
+  }
+
+  @Override
+  public <U> Dataset<U> mapPartitions(final MapPartitionsFunction<T, U> f, final Encoder<U> encoder) {
+    final boolean userTriggered = initializeFunction(f, encoder);
+    final Dataset<U> result = from(super.mapPartitions(f, encoder));
+    this.setIsUserTriggered(userTriggered);
+    return result;
+  }
+
   /**
    * Overrides super.ofRows.
+   *
    * @param sparkSession Spark Session.
-   * @param logicalPlan Spark logical plan.
+   * @param logicalPlan  Spark logical plan.
    * @return Dataset of the given rows.
    */
   public static Dataset<Row> ofRows(final org.apache.spark.sql.SparkSession sparkSession,
@@ -541,6 +595,14 @@ public final class Dataset<T> extends org.apache.spark.sql.Dataset<T> implements
   public Dataset<Row> select(final String col, final String... cols) {
     final boolean userTriggered = initializeFunction(col, cols);
     final Dataset<Row> result = from(super.select(col, cols));
+    this.setIsUserTriggered(userTriggered);
+    return result;
+  }
+
+  @Override
+  public <U1> Dataset<U1> select(final TypedColumn<T, U1> c1) {
+    final boolean userTriggered = initializeFunction(c1);
+    final Dataset<U1> result = from(super.select(c1));
     this.setIsUserTriggered(userTriggered);
     return result;
   }

--- a/compiler/frontend/spark/src/main/java/edu/snu/nemo/compiler/frontend/spark/sql/Dataset.java
+++ b/compiler/frontend/spark/src/main/java/edu/snu/nemo/compiler/frontend/spark/sql/Dataset.java
@@ -16,12 +16,9 @@
 package edu.snu.nemo.compiler.frontend.spark.sql;
 
 import edu.snu.nemo.compiler.frontend.spark.core.java.JavaRDD;
-import org.apache.spark.api.java.function.MapFunction;
-import org.apache.spark.api.java.function.MapPartitionsFunction;
 import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Encoder;
 import org.apache.spark.sql.Row;
-import org.apache.spark.sql.TypedColumn;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.storage.StorageLevel;
 
@@ -62,11 +59,6 @@ public final class Dataset<T> extends org.apache.spark.sql.Dataset<T> implements
    */
   @Override
   public JavaRDD<T> javaRDD() {
-    return this.toJavaRDD();
-  }
-
-  @Override
-  public JavaRDD<T> toJavaRDD() {
     return JavaRDD.of((SparkSession) super.sparkSession(), this);
   }
 
@@ -123,14 +115,6 @@ public final class Dataset<T> extends org.apache.spark.sql.Dataset<T> implements
   public Dataset<T> alias(final scala.Symbol alias) {
     final boolean userTriggered = initializeFunction(alias);
     final Dataset<T> result = from(super.alias(alias));
-    this.setIsUserTriggered(userTriggered);
-    return result;
-  }
-
-  @Override
-  public <U> Dataset<U> as(final Encoder<U> evidence) {
-    final boolean userTriggered = initializeFunction(evidence);
-    final Dataset<U> result = from(super.as(evidence));
     this.setIsUserTriggered(userTriggered);
     return result;
   }
@@ -393,40 +377,6 @@ public final class Dataset<T> extends org.apache.spark.sql.Dataset<T> implements
     return result;
   }
 
-  @Override
-  public <U> Dataset<U> map(final scala.Function1<T, U> func, final Encoder<U> evidence) {
-    final boolean userTriggered = initializeFunction(func, evidence);
-    final Dataset<U> result = from(super.map(func, evidence));
-    this.setIsUserTriggered(userTriggered);
-    return result;
-  }
-
-  @Override
-  public <U> Dataset<U> map(final MapFunction<T, U> func, final Encoder<U> encoder) {
-    final boolean userTriggered = initializeFunction(func, encoder);
-    final Dataset<U> result = from(super.map(func, encoder));
-    this.setIsUserTriggered(userTriggered);
-    return result;
-  }
-
-  @Override
-  public <U> Dataset<U> mapPartitions(
-      final scala.Function1<scala.collection.Iterator<T>, scala.collection.Iterator<U>> func,
-      final Encoder<U> evidence) {
-    final boolean userTriggered = initializeFunction(func, evidence);
-    final Dataset<U> result = from(super.mapPartitions(func, evidence));
-    this.setIsUserTriggered(userTriggered);
-    return result;
-  }
-
-  @Override
-  public <U> Dataset<U> mapPartitions(final MapPartitionsFunction<T, U> f, final Encoder<U> encoder) {
-    final boolean userTriggered = initializeFunction(f, encoder);
-    final Dataset<U> result = from(super.mapPartitions(f, encoder));
-    this.setIsUserTriggered(userTriggered);
-    return result;
-  }
-
   /**
    * Overrides super.ofRows.
    * @param sparkSession Spark Session.
@@ -591,14 +541,6 @@ public final class Dataset<T> extends org.apache.spark.sql.Dataset<T> implements
   public Dataset<Row> select(final String col, final String... cols) {
     final boolean userTriggered = initializeFunction(col, cols);
     final Dataset<Row> result = from(super.select(col, cols));
-    this.setIsUserTriggered(userTriggered);
-    return result;
-  }
-
-  @Override
-  public <U1> Dataset<U1> select(final TypedColumn<T, U1> c1) {
-    final boolean userTriggered = initializeFunction(c1);
-    final Dataset<U1> result = from(super.select(c1));
     this.setIsUserTriggered(userTriggered);
     return result;
   }

--- a/compiler/frontend/spark/src/main/java/edu/snu/nemo/compiler/frontend/spark/sql/SparkSession.java
+++ b/compiler/frontend/spark/src/main/java/edu/snu/nemo/compiler/frontend/spark/sql/SparkSession.java
@@ -20,7 +20,6 @@ import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.rdd.RDD;
-import org.apache.spark.sql.Encoder;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.sources.BaseRelation;
 import org.apache.spark.sql.types.StructType;
@@ -188,30 +187,6 @@ public final class SparkSession extends org.apache.spark.sql.SparkSession implem
   public Dataset<Row> createDataFrame(final RDD<Row> rowRDD, final StructType schema) {
     final boolean userTriggered = initializeFunction(rowRDD, schema);
     final Dataset<Row> result = Dataset.from(super.createDataFrame(rowRDD, schema));
-    this.setIsUserTriggered(userTriggered);
-    return result;
-  }
-
-  @Override
-  public <T> Dataset<T> createDataset(final java.util.List<T> data, final Encoder<T> evidence) {
-    final boolean userTriggered = initializeFunction(data, evidence);
-    final Dataset<T> result = Dataset.from(super.createDataset(data, evidence));
-    this.setIsUserTriggered(userTriggered);
-    return result;
-  }
-
-  @Override
-  public <T> Dataset<T> createDataset(final RDD<T> data, final Encoder<T> evidence) {
-    final boolean userTriggered = initializeFunction(data, evidence);
-    final Dataset<T> result = Dataset.from(super.createDataset(data, evidence));
-    this.setIsUserTriggered(userTriggered);
-    return result;
-  }
-
-  @Override
-  public <T> Dataset<T> createDataset(final scala.collection.Seq<T> data, final Encoder<T> evidence) {
-    final boolean userTriggered = initializeFunction(data, evidence);
-    final Dataset<T> result = Dataset.from(super.createDataset(data, evidence));
     this.setIsUserTriggered(userTriggered);
     return result;
   }

--- a/examples/spark/src/test/java/edu/snu/nemo/examples/spark/SparkITCase.java
+++ b/examples/spark/src/test/java/edu/snu/nemo/examples/spark/SparkITCase.java
@@ -19,9 +19,6 @@ import edu.snu.nemo.client.JobLauncher;
 import edu.snu.nemo.common.test.ArgBuilder;
 import edu.snu.nemo.common.test.ExampleTestUtil;
 import edu.snu.nemo.compiler.optimizer.policy.DefaultPolicy;
-import edu.snu.nemo.examples.spark.sql.JavaSparkSQLExample;
-import edu.snu.nemo.examples.spark.sql.JavaUserDefinedTypedAggregation;
-import edu.snu.nemo.examples.spark.sql.JavaUserDefinedUntypedAggregation;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -74,47 +71,5 @@ public final class SparkITCase {
         .addUserArgs(numParallelism)
         .addOptimizationPolicy(DefaultPolicy.class.getCanonicalName())
         .build());
-  }
-
-  @Test(timeout = TIMEOUT)
-  public void testSparkSQLUserDefinedTypedAggregation() throws Exception {
-    final String inputFileName = "sample_input_employees.json";
-    final String inputFilePath = fileBasePath + inputFileName;
-
-    JobLauncher.main(builder
-        .addJobId(JavaUserDefinedTypedAggregation.class.getSimpleName() + "_test")
-        .addUserMain(JavaUserDefinedTypedAggregation.class.getCanonicalName())
-        .addUserArgs(inputFilePath)
-        .addOptimizationPolicy(DefaultPolicy.class.getCanonicalName())
-        .build());
-  }
-
-  @Test(timeout = TIMEOUT)
-  public void testSparkSQLUserDefinedUntypedAggregation() throws Exception {
-    final String inputFileName = "sample_input_employees.json";
-    final String inputFilePath = fileBasePath + inputFileName;
-
-    JobLauncher.main(builder
-        .addJobId(JavaUserDefinedUntypedAggregation.class.getSimpleName() + "_test")
-        .addUserMain(JavaUserDefinedUntypedAggregation.class.getCanonicalName())
-        .addUserArgs(inputFilePath)
-        .addOptimizationPolicy(DefaultPolicy.class.getCanonicalName())
-        .build());
-  }
-
-  @Test(timeout = TIMEOUT)
-  public void testSparkSQLExample() throws Exception {
-    final String peopleJson = "sample_input_people.json";
-    final String peopleTxt = "sample_input_people.txt";
-    final String inputFileJson = fileBasePath + peopleJson;
-    final String inputFileTxt = fileBasePath + peopleTxt;
-
-//    TODO#412: Enable this after implementation of RDDs.
-//    JobLauncher.main(builder
-//        .addJobId(JavaSparkSQLExample.class.getSimpleName() + "_test")
-//        .addUserMain(JavaSparkSQLExample.class.getCanonicalName())
-//        .addUserArgs(inputFileJson, inputFileTxt)
-//        .addOptimizationPolicy(DefaultPolicy.class.getCanonicalName())
-//        .build());
   }
 }

--- a/examples/spark/src/test/java/edu/snu/nemo/examples/spark/SparkITCase.java
+++ b/examples/spark/src/test/java/edu/snu/nemo/examples/spark/SparkITCase.java
@@ -19,6 +19,8 @@ import edu.snu.nemo.client.JobLauncher;
 import edu.snu.nemo.common.test.ArgBuilder;
 import edu.snu.nemo.common.test.ExampleTestUtil;
 import edu.snu.nemo.compiler.optimizer.policy.DefaultPolicy;
+import edu.snu.nemo.examples.spark.sql.JavaUserDefinedTypedAggregation;
+import edu.snu.nemo.examples.spark.sql.JavaUserDefinedUntypedAggregation;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -71,5 +73,47 @@ public final class SparkITCase {
         .addUserArgs(numParallelism)
         .addOptimizationPolicy(DefaultPolicy.class.getCanonicalName())
         .build());
+  }
+
+  @Test(timeout = TIMEOUT)
+  public void testSparkSQLUserDefinedTypedAggregation() throws Exception {
+    final String inputFileName = "sample_input_employees.json";
+    final String inputFilePath = fileBasePath + inputFileName;
+
+    JobLauncher.main(builder
+        .addJobId(JavaUserDefinedTypedAggregation.class.getSimpleName() + "_test")
+        .addUserMain(JavaUserDefinedTypedAggregation.class.getCanonicalName())
+        .addUserArgs(inputFilePath)
+        .addOptimizationPolicy(DefaultPolicy.class.getCanonicalName())
+        .build());
+  }
+
+  @Test(timeout = TIMEOUT)
+  public void testSparkSQLUserDefinedUntypedAggregation() throws Exception {
+    final String inputFileName = "sample_input_employees.json";
+    final String inputFilePath = fileBasePath + inputFileName;
+
+    JobLauncher.main(builder
+        .addJobId(JavaUserDefinedUntypedAggregation.class.getSimpleName() + "_test")
+        .addUserMain(JavaUserDefinedUntypedAggregation.class.getCanonicalName())
+        .addUserArgs(inputFilePath)
+        .addOptimizationPolicy(DefaultPolicy.class.getCanonicalName())
+        .build());
+  }
+
+  @Test(timeout = TIMEOUT)
+  public void testSparkSQLExample() throws Exception {
+    final String peopleJson = "sample_input_people.json";
+    final String peopleTxt = "sample_input_people.txt";
+    final String inputFileJson = fileBasePath + peopleJson;
+    final String inputFileTxt = fileBasePath + peopleTxt;
+
+    //    TODO#412: Enable this after implementation of RDDs.
+    //    JobLauncher.main(builder
+    //        .addJobId(JavaSparkSQLExample.class.getSimpleName() + "_test")
+    //        .addUserMain(JavaSparkSQLExample.class.getCanonicalName())
+    //        .addUserArgs(inputFileJson, inputFileTxt)
+    //        .addOptimizationPolicy(DefaultPolicy.class.getCanonicalName())
+    //        .build());
   }
 }

--- a/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/data/BlockManagerWorker.java
+++ b/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/data/BlockManagerWorker.java
@@ -189,7 +189,9 @@ public final class BlockManagerWorker {
 
     // Using thenCompose so that fetching block data starts after getting response from master.
     return blockLocationFuture.thenCompose(responseFromMaster -> {
-      assert (responseFromMaster.getType() == ControlMessage.MessageType.BlockLocationInfo);
+      if (responseFromMaster.getType() != ControlMessage.MessageType.BlockLocationInfo) {
+        throw new RuntimeException("Response message type mismatch!");
+      }
       final ControlMessage.BlockLocationInfoMsg blockLocationInfoMsg =
           responseFromMaster.getBlockLocationInfoMsg();
       if (!blockLocationInfoMsg.hasOwnerExecutorId()) {

--- a/runtime/master/src/main/java/edu/snu/nemo/runtime/master/BlockManagerMaster.java
+++ b/runtime/master/src/main/java/edu/snu/nemo/runtime/master/BlockManagerMaster.java
@@ -31,6 +31,8 @@ import javax.annotation.concurrent.ThreadSafe;
 import javax.inject.Inject;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -120,13 +122,13 @@ public final class BlockManagerMaster {
   }
 
   /**
-   * Returns a {@link CompletableFuture} of block location, which is not yet resolved in {@code SCHEDULED} state.
+   * Returns a handler of block location requests.
    *
    * @param blockId id of the specified block.
-   * @return {@link CompletableFuture} of block location, which completes exceptionally when the block
-   *         is not {@code SCHEDULED} or {@code COMMITTED}.
+   * @return the handler of block location requests, which completes exceptionally when the block
+   * is not {@code SCHEDULED} or {@code COMMITTED}.
    */
-  public CompletableFuture<String> getBlockLocationFuture(final String blockId) {
+  public BlockLocationRequestHandler getBlockLocationHandler(final String blockId) {
     final Lock readLock = lock.readLock();
     readLock.lock();
     try {
@@ -135,14 +137,14 @@ public final class BlockManagerMaster {
       switch (state) {
         case SCHEDULED:
         case COMMITTED:
-          return blockIdToMetadata.get(blockId).getLocationFuture();
+          return blockIdToMetadata.get(blockId).getLocationHandler();
         case READY:
         case LOST_BEFORE_COMMIT:
         case LOST:
         case REMOVED:
-          final CompletableFuture<String> future = new CompletableFuture<>();
-          future.completeExceptionally(new AbsentBlockException(blockId, state));
-          return future;
+          final BlockLocationRequestHandler handler = new BlockLocationRequestHandler(blockId);
+          handler.completeExceptionally(new AbsentBlockException(blockId, state));
+          return handler;
         default:
           throw new UnsupportedOperationException(state.toString());
       }
@@ -241,9 +243,16 @@ public final class BlockManagerMaster {
     try {
       final Set<String> blockIds = new HashSet<>();
       blockIdToMetadata.values().forEach(blockMetadata -> {
-        final String location = blockMetadata.getLocationFuture().getNow("NOT_COMMITTED");
-        if (location.equals(executorId)) {
-          blockIds.add(blockMetadata.getBlockId());
+        final Future<String> location = blockMetadata.getLocationHandler().getLocationFuture();
+        if (location.isDone()) {
+          try {
+            if (location.get().equals(executorId)) {
+              blockIds.add(blockMetadata.getBlockId());
+            }
+          } catch (final InterruptedException | ExecutionException e) {
+            // Cannot reach here because we check the completion of the future already.
+            LOG.error("Exception while getting the location of a block!", e);
+          }
         }
       });
       return blockIds;
@@ -253,9 +262,8 @@ public final class BlockManagerMaster {
   }
 
   /**
-   * @return the {@link BlockState} of a block.
-   *
    * @param blockId the id of the block.
+   * @return the {@link BlockState} of a block.
    */
   @VisibleForTesting
   BlockState getBlockState(final String blockId) {
@@ -271,10 +279,10 @@ public final class BlockManagerMaster {
   /**
    * Deals with state change of a block.
    *
-   * @param blockId     the id of the block.
-   * @param newState        the new state of the block.
-   * @param location        the location of the block (e.g., worker id, remote store).
-   *                        {@code null} if not committed or lost.
+   * @param blockId  the id of the block.
+   * @param newState the new state of the block.
+   * @param location the location of the block (e.g., worker id, remote store).
+   *                 {@code null} if not committed or lost.
    */
   @VisibleForTesting
   public void onBlockStateChanged(final String blockId,
@@ -303,27 +311,8 @@ public final class BlockManagerMaster {
     final Lock readLock = lock.readLock();
     readLock.lock();
     try {
-      final CompletableFuture<String> locationFuture
-          = getBlockLocationFuture(blockId);
-      locationFuture.whenComplete((location, throwable) -> {
-        final ControlMessage.BlockLocationInfoMsg.Builder infoMsgBuilder =
-            ControlMessage.BlockLocationInfoMsg.newBuilder()
-                .setRequestId(requestId)
-                .setBlockId(blockId);
-        if (throwable == null) {
-          infoMsgBuilder.setOwnerExecutorId(location);
-        } else {
-          infoMsgBuilder.setState(
-              convertBlockState(((AbsentBlockException) throwable).getState()));
-        }
-        messageContext.reply(
-            ControlMessage.Message.newBuilder()
-                .setId(RuntimeIdGenerator.generateMessageId())
-                .setListenerId(MessageEnvironment.EXECUTOR_MESSAGE_LISTENER_ID)
-                .setType(ControlMessage.MessageType.BlockLocationInfo)
-                .setBlockLocationInfoMsg(infoMsgBuilder.build())
-                .build());
-      });
+      final BlockLocationRequestHandler locationFuture = getBlockLocationHandler(blockId);
+      locationFuture.registerRequest(requestId, messageContext);
     } finally {
       readLock.unlock();
     }
@@ -366,6 +355,84 @@ public final class BlockManagerMaster {
               new Exception("This message should not be received by "
                   + BlockManagerMaster.class.getName() + ":" + message.getType()));
       }
+    }
+  }
+
+  /**
+   * The handler of block location requests.
+   */
+  @VisibleForTesting
+  public static final class BlockLocationRequestHandler {
+    private final String blockId;
+    private final CompletableFuture<String> locationFuture;
+
+    /**
+     * Constructor.
+     *
+     * @param blockId the ID of the block.
+     */
+    BlockLocationRequestHandler(final String blockId) {
+      this.blockId = blockId;
+      this.locationFuture = new CompletableFuture<>();
+    }
+
+    /**
+     * Completes the block location future.
+     * If there is any pending request, replies with the completed location.
+     *
+     * @param location the location of the block.
+     */
+    void complete(final String location) {
+      locationFuture.complete(location);
+    }
+
+    /**
+     * Completes the block location future with failure.
+     * If there is any pending request, replies with the cause.
+     *
+     * @param throwable the cause of failure.
+     */
+    void completeExceptionally(final Throwable throwable) {
+      locationFuture.completeExceptionally(throwable);
+    }
+
+    /**
+     * Registers a request for the block location.
+     * If the location is already known, reply the location instantly.
+     *
+     * @param requestId      the ID of the block location request.
+     * @param messageContext the message context to reply.
+     */
+    void registerRequest(final long requestId,
+                         final MessageContext messageContext) {
+      final ControlMessage.BlockLocationInfoMsg.Builder infoMsgBuilder =
+          ControlMessage.BlockLocationInfoMsg.newBuilder()
+              .setRequestId(requestId)
+              .setBlockId(blockId);
+
+      locationFuture.whenComplete((location, throwable) -> {
+        if (throwable == null) {
+          infoMsgBuilder.setOwnerExecutorId(location);
+        } else {
+          infoMsgBuilder.setState(
+              convertBlockState(((AbsentBlockException) throwable).getState()));
+        }
+        messageContext.reply(
+            ControlMessage.Message.newBuilder()
+                .setId(RuntimeIdGenerator.generateMessageId())
+                .setListenerId(MessageEnvironment.EXECUTOR_MESSAGE_LISTENER_ID)
+                .setType(ControlMessage.MessageType.BlockLocationInfo)
+                .setBlockLocationInfoMsg(infoMsgBuilder.build())
+                .build());
+      });
+    }
+
+    /**
+     * @return the future of the block location.
+     */
+    @VisibleForTesting
+    public synchronized Future<String> getLocationFuture() {
+      return locationFuture;
     }
   }
 }

--- a/runtime/master/src/main/java/edu/snu/nemo/runtime/master/BlockManagerMaster.java
+++ b/runtime/master/src/main/java/edu/snu/nemo/runtime/master/BlockManagerMaster.java
@@ -431,7 +431,7 @@ public final class BlockManagerMaster {
      * @return the future of the block location.
      */
     @VisibleForTesting
-    public synchronized Future<String> getLocationFuture() {
+    public Future<String> getLocationFuture() {
       return locationFuture;
     }
   }


### PR DESCRIPTION
This PR:
- collects the request messages for a single block in driver and handle them with a single block id string instance.
- shares the `Future` of a block location response in executor if a request for the same block is already pending.

Resolves #787.