### PR TITLE
[Minor] Set default executor conf for unit tests, and fix setRepresentativeEdgeId

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@
 # .travis.yml
 # For maven builds
 language: java
-after_script: "mvn verify -B"
+script: "mvn verify -B"
 
 notifications:
   slack: snuspl:owgt4d5uZwww5nGovPAMgvZB

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Nemo
 
-[![Build Status](https://travis-ci.org/snuspl/nemo.svg?branch=master)](https://travis-ci.org/snuspl/nemo)
-[![Build Status](https://cmsbuild.snu.ac.kr/buildStatus/icon?job=Nemo-master)](https://cmsbuild.snu.ac.kr/job/Nemo-master/)
+[![Build Status](https://travis-ci.org/apache/incubator-nemo.svg?branch=master)](https://travis-ci.org/apache/incubator-nemo)
 
 ## Nemo prerequisites and setup
 

--- a/common/src/main/java/edu/snu/nemo/common/ir/edge/executionproperty/DuplicateEdgeGroupPropertyValue.java
+++ b/common/src/main/java/edu/snu/nemo/common/ir/edge/executionproperty/DuplicateEdgeGroupPropertyValue.java
@@ -44,7 +44,7 @@ public final class DuplicateEdgeGroupPropertyValue implements Serializable {
    * @param representativeEdgeId physical edge id of representative edge.
    */
   public void setRepresentativeEdgeId(final String representativeEdgeId) {
-    if (isRepresentativeEdgeDecided) {
+    if (isRepresentativeEdgeDecided && !this.representativeEdgeId.equals(representativeEdgeId)) {
       throw new RuntimeException("edge id is already decided");
     }
     this.isRepresentativeEdgeDecided = true;

--- a/common/src/main/java/edu/snu/nemo/common/test/ArgBuilder.java
+++ b/common/src/main/java/edu/snu/nemo/common/test/ArgBuilder.java
@@ -20,11 +20,14 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Argument builder.
  */
 public final class ArgBuilder {
+  private static final List<List<String>> DEFAULT_ARGS = Arrays.asList(Arrays.asList("-executor_json",
+      "../resources/sample_executor_resources.json"));
   private List<List<String>> args = new ArrayList<>();
 
   /**
@@ -80,6 +83,7 @@ public final class ArgBuilder {
   public String[] build() {
     // new String[0] is good for performance
     // see http://stackoverflow.com/questions/4042434/converting-arrayliststring-to-string-in-java
-    return args.stream().flatMap(List::stream).collect(Collectors.toList()).toArray(new String[0]);
+    return Stream.concat(args.stream().flatMap(List::stream), DEFAULT_ARGS.stream().flatMap(List::stream))
+        .collect(Collectors.toList()).toArray(new String[0]);
   }
 }

--- a/tests/src/test/java/edu/snu/nemo/tests/compiler/CompilerTestUtil.java
+++ b/tests/src/test/java/edu/snu/nemo/tests/compiler/CompilerTestUtil.java
@@ -61,7 +61,7 @@ public final class CompilerTestUtil {
 
   public static DAG<IRVertex, IREdge> compileMRDAG() throws Exception {
     final String input = rootDir + "/../examples/resources/sample_input_mr";
-    final String output = rootDir + "/../examples-beam/src/main/resources/sample_output";
+    final String output = rootDir + "/../examples/beam/src/main/resources/sample_output";
     final String main = "edu.snu.nemo.examples.beam.MapReduce";
 
     final ArgBuilder mrArgBuilder = new ArgBuilder()


### PR DESCRIPTION
This commit resolves multiple issues that we've missed because of wrong CI configuration.

* Sets default ExecutorJsonPath value for unit tests.
* Allow multiple setRepresentativeEdgeId invocation with same edgeId.
* .travis.yml: Let failing ITCases fail Travis CI build.